### PR TITLE
Fix an erroneous size argument to strncmp in readAmpl.

### DIFF
--- a/Cbc/src/Cbc_ampl.cpp
+++ b/Cbc/src/Cbc_ampl.cpp
@@ -597,7 +597,7 @@ int readAmpl(ampl_info *info, int argc, char **argv, void **coinModel)
       const char *argument = info->arguments[i];
       for (j = 0; j < sizeof(something) / sizeof(char *); j++) {
         const char *check = something[j];
-        if (!strncmp(argument, check, sizeof(check))) {
+        if (!strncmp(argument, check, strlen(check))) {
           found = (int)(j + 1);
         } else if (!strncmp(argument, "log", 3)) {
           foundLog = 1;


### PR DESCRIPTION
GCC 9 flagged the size argument to the strncmp call changed by this commit as suspicious.  Since check has type const char *, then sizeof(check) is the size of a pointer; i.e., 4 or 8.  If the intent was to check that argument begins with the string something[j], by analogy to the "log" and "sleep" checks below, then strlen(check) is the appropriate number.  If you want an exact match, then sizeof(something[j]) is the correct number, but in that case you may as well just write "if (!strcmp(argument, check))".