### PR TITLE
Clearing header from undefined implementation

### DIFF
--- a/Cbc/src/CbcModel.hpp
+++ b/Cbc/src/CbcModel.hpp
@@ -2427,7 +2427,6 @@ public:
     bool &resolved, CoinWarmStartBasis *lastws,
     const double *lowerBefore, const double *upperBefore,
     OsiSolverBranch *&branches);
-  int chooseBranch(CbcNode *newNode, int numberPassesLeft, bool &resolved);
 
   /** Return an empty basis object of the specified size
 

--- a/Cbc/src/CbcModel.hpp
+++ b/Cbc/src/CbcModel.hpp
@@ -2501,8 +2501,6 @@ public:
   void synchronizeNumberBeforeTrust(int type = 0);
   /// Zap integer information in problem (may leave object info)
   void zapIntegerInformation(bool leaveObjects = true);
-  /// Use cliques for pseudocost information - return nonzero if infeasible
-  int cliquePseudoCosts(int doStatistics);
   /// Fill in useful estimates
   void pseudoShadow(int type);
   /** Return pseudo costs

--- a/Cbc/src/CbcModel.hpp
+++ b/Cbc/src/CbcModel.hpp
@@ -2348,9 +2348,11 @@ public:
   }
   /// From here to end of section - code in CbcThread.cpp until class changed
   /// Returns true if locked
-  bool isLocked() const;
-#ifdef CBC_THREAD
-  /**
+#ifndef CBC_THREAD
+  inline void lockThread() {}
+  inline void unlockThread() {}
+#else
+  /**i
        Locks a thread if parallel so that stuff like cut pool
        can be updated and/or used.
     */
@@ -2359,12 +2361,7 @@ public:
        Unlocks a thread if parallel to say cut pool stuff not needed
     */
   void unlockThread();
-#else
-  inline void lockThread()
-  {
-  }
-  inline void unlockThread() {}
-#endif
+  
   /** Set information in a child
         -3 pass pointer to child thread info
         -2 just stop
@@ -2389,7 +2386,7 @@ public:
   void mergeModels(int numberModel, CbcModel **model,
     int numberNodes);
   //@}
-
+#endif
   ///@name semi-private i.e. users should not use
   //@{
   /// Get how many Nodes it took to solve the problem.
@@ -3263,13 +3260,8 @@ void CbcMain0(CbcModel &babSolver);
 int CbcMain1(int argc, const char *argv[], CbcModel &babSolver);
 // two ways of calling
 int callCbc(const char *input2, CbcModel &babSolver);
-int callCbc(const std::string input2, CbcModel &babSolver);
-// And when CbcMain0 already called to initialize
-int callCbc1(const char *input2, CbcModel &babSolver);
-int callCbc1(const std::string input2, CbcModel &babSolver);
 // And when CbcMain0 already called to initialize (with call back) (see CbcMain1 for whereFrom)
 int callCbc1(const char *input2, CbcModel &babSolver, int(CbcModel *currentSolver, int whereFrom));
-int callCbc1(const std::string input2, CbcModel &babSolver, int(CbcModel *currentSolver, int whereFrom));
 int CbcMain1(int argc, const char *argv[], CbcModel &babSolver, int(CbcModel *currentSolver, int whereFrom));
 // For uniform setting of cut and heuristic options
 void setCutAndHeuristicOptions(CbcModel &model);


### PR DESCRIPTION
For Python and Java Native interface code generation, I need to clean-up the headers to remove all the undefined symbol.