### PR TITLE
Set RuntimeLibrary (Multithreaded DLL, etc) setting for VS2019 to default

### DIFF
--- a/MSVisualStudio/v16/libCbc/libCbc.vcxproj
+++ b/MSVisualStudio/v16/libCbc/libCbc.vcxproj
@@ -176,7 +176,6 @@
       <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\Cgl\src\CglBKClique;..\..\..\..\Cgl\src\CglCommon;..\..\..\..\Cgl\src\CglClique;..\..\..\..\Cgl\src\CglCliqueStrengthening;..\..\..\..\Cgl\src\CglZeroHalf;..\..\..\..\Cgl\src\CglGMI;..\..\..\..\Cgl\src\CglLandP;..\..\..\..\Cgl\src\CglTwomir;..\..\..\..\Cgl\src\CglMixedIntegerRounding;..\..\..\..\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\Cgl\src\CglFlowCover;..\..\..\..\Cgl\src\CglOddHole;..\..\..\..\Cgl\src\CglOddWheel;..\..\..\..\Cgl\src\CglKnapsackCover;..\..\..\..\Cgl\src\CglGomory;..\..\..\..\Cgl\src\CglPreProcess;..\..\..\..\Cgl\src\CglDuplicateRow;..\..\..\..\Cgl\src\CglRedSplit;..\..\..\..\Cgl\src\CglProbing;..\..\..\..\Cgl\src;..\..\..\..\Clp\src;..\..\..\..\Clp\src\OsiClp;..\..\..\..\Osi\src\Osi;..\..\..\..\CoinUtils\src;..\..\..\..\BuildTools\headers;..\..\..\..\Cgl\src\CglResidualCapacity;..\..\..\..\Cgl\src\CglRedSplit2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_NDEBUG;CBCLIB_BUILD;WIN32;_LIB;USE_CBCCONFIG;COIN_NO_CLP_MESSAGE;_CRT_SECURE_NO_WARNINGS;_CRT_SECURE_NO_DEPRECATE;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/MSVisualStudio/v16/libCbcSolver/libCbcSolver.vcxproj
+++ b/MSVisualStudio/v16/libCbcSolver/libCbcSolver.vcxproj
@@ -176,7 +176,6 @@
       <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\Cgl\src\CglOddWheel;..\..\..\..\Cgl\src\CglCliqueStrengthening;..\..\..\..\Cgl\src\CglCommon;..\..\..\..\Cgl\src\CglOddHoleWC;..\..\..\..\Cgl\src\CglCliqueMerging;..\..\..\..\Cgl\src\CglBKClique;..\..\..\..\Cgl\src\CglZeroHalf;..\..\..\..\Cgl\src\CglGMI;..\..\..\..\Cgl\src\CglLandP;..\..\..\..\Cgl\src\CglTwomir;..\..\..\..\Cgl\src\CglMixedIntegerRounding;..\..\..\..\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\Cgl\src\CglFlowCover;..\..\..\..\Cgl\src\CglClique;..\..\..\..\Cgl\src\CglOddHole;..\..\..\..\Cgl\src\CglKnapsackCover;..\..\..\..\Cgl\src\CglGomory;..\..\..\..\Cgl\src\CglPreProcess;..\..\..\..\Cgl\src\CglDuplicateRow;..\..\..\..\Cgl\src\CglRedSplit;..\..\..\..\Cgl\src\CglProbing;..\..\..\..\Cgl\src;..\..\..\..\Clp\src;..\..\..\..\Clp\src\OsiClp;..\..\..\..\Osi\src\Osi;..\..\..\..\CoinUtils\src;..\..\..\..\BuildTools\headers;..\..\..\..\Cgl\src\CglResidualCapacity;..\..\..\..\Cgl\src\CglRedSplit2;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
       <PreprocessorDefinitions>NDEBUG;_NDEBUG;CBCLIB_BUILD;WIN32;_CRT_SECURE_NO_WARNINGS;_MBCS;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <MultiProcessorCompilation>true</MultiProcessorCompilation>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
     <Link>
       <SubSystem>Console</SubSystem>

--- a/MSVisualStudio/v16/libOsiCbc/libOsiCbc.vcxproj
+++ b/MSVisualStudio/v16/libOsiCbc/libOsiCbc.vcxproj
@@ -126,7 +126,6 @@
       <WarningLevel>Level3</WarningLevel>
       <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
       <InlineFunctionExpansion>Default</InlineFunctionExpansion>
-      <RuntimeLibrary>MultiThreaded</RuntimeLibrary>
     </ClCompile>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
For libCbc, libCbcSolver and libOsiCbc, this PR sets RuntimeLibrary (Multithreaded DLL, etc.--how to link in the Microsoft Run-Time library MSVCRT / LIBCMT) for VS2019 to default values for all configurations by removing explicit values.

All Debug configs were at defaults, but Release were various, leading to link errors when linking multiple libraries together. These conflicts are prevented if all simply use the default (Multithreaded DLL (Debug or Release)). This has nothing to do with the result of the Configuration Type (static lib, dll, exe, etc.), but only how the MS runtimes are linked.