### PR TITLE
Maintained the unmaintained OsiCbc to account for the changes in maxLen

### DIFF
--- a/src/OsiCbc/OsiCbcSolverInterface.cpp
+++ b/src/OsiCbc/OsiCbcSolverInterface.cpp
@@ -767,12 +767,12 @@ OsiCbcSolverInterface::dfltRowColName(char rc, int ndx, unsigned digits) const
   return (modelPtr_->solver()->dfltRowColName(rc, ndx, digits));
 }
 
-std::string OsiCbcSolverInterface::getObjName(std::string::size_type maxLen) const
+std::string OsiCbcSolverInterface::getObjName(unsigned maxLen) const
 {
   return (modelPtr_->solver()->getObjName(maxLen));
 }
 
-std::string OsiCbcSolverInterface::getRowName(int ndx, std::string::size_type maxLen) const
+std::string OsiCbcSolverInterface::getRowName(int ndx, unsigned maxLen) const
 {
   return (modelPtr_->solver()->getRowName(ndx, maxLen));
 }
@@ -782,7 +782,7 @@ const OsiSolverInterface::OsiNameVec &OsiCbcSolverInterface::getRowNames()
   return (modelPtr_->solver()->getRowNames());
 }
 
-std::string OsiCbcSolverInterface::getColName(int ndx, std::string::size_type maxLen) const
+std::string OsiCbcSolverInterface::getColName(int ndx, unsigned maxLen) const
 {
   return (modelPtr_->solver()->getColName(ndx, maxLen));
 }

--- a/src/OsiCbc/OsiCbcSolverInterface.hpp
+++ b/src/OsiCbc/OsiCbcSolverInterface.hpp
@@ -299,7 +299,7 @@ public:
 
   /*! \brief Return the name of the objective function */
 
-  virtual std::string getObjName(std::string::size_type maxLen = std::string::npos) const;
+  virtual std::string getObjName(unsigned maxLen = static_cast< unsigned >(std::string::npos)) const;
 
   /*! \brief Set the name of the objective function */
 
@@ -308,7 +308,7 @@ public:
   /*! \brief Return the name of the row.  */
 
   virtual std::string getRowName(int rowIndex,
-    std::string::size_type maxLen = std::string::npos) const;
+    unsigned maxLen = static_cast< unsigned >(std::string::npos)) const;
 
   /*! \brief Return a pointer to a vector of row names */
 
@@ -330,7 +330,7 @@ public:
   /*! \brief Return the name of the column */
 
   virtual std::string getColName(int colIndex,
-    std::string::size_type maxLen = std::string::npos) const;
+    unsigned maxLen = static_cast< unsigned >(std::string::npos)) const;
 
   /*! \brief Return a pointer to a vector of column names */
 


### PR DESCRIPTION
Maintained the unmaintained OsiCbc to account for the changes in maxLen from size_type to unsigned in Osi. This broke the inheritance at OsiCbc, and as a consequence the writeLp and similar no longer worked.