### PR TITLE
fix initializations of CbcParameters::parameters_

### DIFF
--- a/src/CbcLinked.cpp
+++ b/src/CbcLinked.cpp
@@ -5215,7 +5215,7 @@ void OsiBiLinear::addExtraRow(int row, double multiplier)
   delete[] multiplier_;
   multiplier_ = tempD;
 }
-static bool testCoarse = true;
+static const bool testCoarse = true;
 // Infeasibility - large is 0.5
 double
 OsiBiLinear::infeasibility(const OsiBranchingInformation *info, int &whichWay) const

--- a/src/CbcParameters.cpp
+++ b/src/CbcParameters.cpp
@@ -33,7 +33,7 @@ CbcParameters::CbcParameters() : parameters_(CbcParam::LASTPARAM), model_(0)
       string instead?
     */
   for (int i = 0; i < parameters_.size(); i++){
-     parameters_[i] = new ClpParam();
+     parameters_[i] = new CbcParam();
   }
 
   char dirsep = CoinFindDirSeparator();


### PR DESCRIPTION
parameters_[i] is static_cast'd to CbcParam in getParam and without this PR any access of properties that are in CbcParam but not in ClpParam cause invalid memory access.

This is a hotfix to get the refactor branch running, imho we should kill that static_cast later.