### PR TITLE
Fix an assertion which is raised when CoinOR is compiled with _GLIBCXX_DEBUG

### DIFF
--- a/src/CbcCompare.hpp
+++ b/src/CbcCompare.hpp
@@ -22,6 +22,7 @@ public:
 
   bool operator()(CbcNode *x, CbcNode *y)
   {
+    if (x == y) return false;
     return test_->test(x, y);
   }
   bool compareNodes(CbcNode *x, CbcNode *y)


### PR DESCRIPTION
CbcTree::push calls std::push_heap which expects CbcCompare to be a compliant comparator.
The debug version of push_heap intentionally compares elements with themselves to check compliance.

The actual production code which triggered this bug had the following call stack:
```c++
CbcCompareBase.hpp@6849: assert (nodeNumberX != nodeNumberY);
CbcCompareBase::equalityTest(CbcNode *, CbcNode*)

CbcCompareDefault.hpp@220: return equalityTest (x,y); //so ties will be broken in consistent manner
CbcCompareDefault::test(CbcNode *, CbcNode *)

CbcCompare.hpp@22: return test_->test(x, y);
CbcCompare::operator()(CbcNode *, CbcNode*)

stl_heap.h@209: __glibcxx_requires_irreflexive_pred(__first, __last, __comp);
std::push_heap<std::__debug::vector::iterator, CbcCompare>(vector::iterator, vector::iterator, CbcCompare)

CbcTree.cpp@386: std::push_heap(nodes_.begin(), nodes_.end(), comparison_);
CbcTree::push(CbcNode*)

CbcModel.cpp@4150: tree_->push(newNode) ;
CbcModel::branchAndBound(int)

CbcHeuristic.cpp@1376: model.branchAndBound();
CbcHeuristic::smallBranchAndBound(OsiSolverInterface*, int, double*, double&, double, std::string)

CbcHeuristicFPump.cpp@1987: int returnCode2 = smallBranchAndBound(newSolver, numberNodes_, newSolution, newSolutionValue, cutoff2, "CbcHeuristicLocalAfterFPump");
CbcHeuristicFPump::solution(double&, double*)

CbcModel.cpp@15613: int ifSol = heuristic_[i]->solution(heuristicValue, newSolution);
CbcModel::doHeuristicsAtRoot(int)

CbcModel.cpp@2804: doHeuristicsAtRoot();
CbcModel::branchAndBound(int)

CbcSolver.cpp@6849: babModel_->branchAndBound(statistics);
CbcMain1(int, char const*, CbcModel&, int(CbcModel*, int))

CbcSolver.cpp@1133: int returnCode = CbcMain1(n + 2, const_cast<const char **>(argv), model, callBack, parameterData);
callCbc1(char const*, CbcModel&, int(CbcModel*, int), CbcSolverUsefulData&)

CbcSolver.cpp@1039: return callCbc1(input2, babSolver, dummyCallback, data);
callCbc(char const*, OsiClpSolverInterface&)

[external code]
```

I verified that the bug still occurs with master versions of CoinUtils, Osi, Clp, Cgl and Cbc with this [minimal working example](https://gist.github.com/brjsp/3e1fa7592aca44fd487867e6f8838981).