### PR TITLE
Fix compiler warnings

### DIFF
--- a/Cbc/src/CbcHeuristic.cpp
+++ b/Cbc/src/CbcHeuristic.cpp
@@ -196,6 +196,7 @@ CbcHeuristic::operator=(const CbcHeuristic &rhs)
   return *this;
 }
 
+static
 void CbcHeurDebugNodes(CbcModel *model_)
 {
   CbcNode *node = model_->currentNode();

--- a/Cbc/src/CbcHeuristicDW.cpp
+++ b/Cbc/src/CbcHeuristicDW.cpp
@@ -1097,16 +1097,16 @@ int CbcHeuristicDW::solution(double &solutionValue,
       //model.solver()->setHintParam(OsiDoPresolveInResolve, false, OsiHintDo, 0) ;
       model.initialSolve();
       if (bestObjective_ > model.solver()->getObjValue() + 1.0e-1) {
-        const double *dj = model.solver()->getReducedCost();
         int nFix = 0;
+#ifdef HOT_START
+        // Set up hot start
+        const double *dj = model.solver()->getReducedCost();
         const double *lower = model.solver()->getColLower();
         const double *upper = model.solver()->getColUpper();
         const double *solution = model.solver()->getColSolution();
         double gap = CoinMax(bestObjective_ - model.solver()->getObjValue(),
           1.0e-3);
         int numberColumns2 = model.solver()->getNumCols();
-#ifdef HOT_START
-        // Set up hot start
         const int *originalColumns = pinfo.originalColumns();
         double *hot = new double[2 * numberColumns2];
         int *hotPriorities = new int[numberColumns2 * 2];

--- a/Cbc/src/CbcHeuristicDive.cpp
+++ b/Cbc/src/CbcHeuristicDive.cpp
@@ -402,7 +402,9 @@ int CbcHeuristicDive::solution(double &solutionValue, int &numberNodes,
   int iteration = 0;
   int numberAtBoundFixed = 0;
   int numberGeneralFixed = 0; // fixed as satisfied but not at bound
+#if DIVE_PRINT > 1
   int numberReducedCostFixed = 0;
+#endif
   while (numberFractionalVariables) {
     iteration++;
 

--- a/Cbc/src/CbcLinked.cpp
+++ b/Cbc/src/CbcLinked.cpp
@@ -140,7 +140,7 @@ void OsiSolverLink::initialSolve()
     for (int i = 0; i < numberVariables_; i++) {
       info_[i].updateBounds(modelPtr_);
     }
-    int updated = updateCoefficients(modelPtr_, temp);
+    /* int updated =*/ updateCoefficients(modelPtr_, temp);
     //if (updated || 1) {
       temp->removeGaps(1.0e-14);
       ClpMatrixBase *save = modelPtr_->clpMatrix();

--- a/Cbc/src/CbcLinked.cpp
+++ b/Cbc/src/CbcLinked.cpp
@@ -7147,6 +7147,7 @@ CglTemporary::operator=(const CglTemporary &rhs)
   }
   return *this;
 }
+static
 void checkQP(ClpSimplex * /*model*/)
 {
 #ifdef JJF_ZERO

--- a/Cbc/src/CbcMipStartIO.cpp
+++ b/Cbc/src/CbcMipStartIO.cpp
@@ -18,6 +18,7 @@
 
 using namespace std;
 
+static
 bool isNumericStr(const char *str)
 {
   const size_t l = strlen(str);

--- a/Cbc/src/CbcMipStartIO.cpp
+++ b/Cbc/src/CbcMipStartIO.cpp
@@ -71,7 +71,7 @@ int readMIPStart(CbcModel *model, const char *fileName,
   if (colValues.size()) {
     sprintf(printLine, "MIPStart values read for %d variables.", static_cast< int >(colValues.size()));
     model->messageHandler()->message(CBC_GENERAL, model->messages()) << printLine << CoinMessageEol;
-    if (colValues.size() < model->getNumCols()) {
+    if ((int)colValues.size() < model->getNumCols()) {
       int numberColumns = model->getNumCols();
       OsiSolverInterface *solver = model->solver();
       vector< pair< string, double > > fullValues;
@@ -120,7 +120,7 @@ int computeCompleteSolution(CbcModel *model,
   for (int i = 0; (i < static_cast< int >(colNames.size())); ++i)
     colIdx[colNames[i]] = i;
 
-  char printLine[STR_SIZE];
+  char printLine[STR_SIZE+100];
   int fixed = 0;
   int notFound = 0;
   char colNotFound[256] = "";

--- a/Cbc/src/CbcModel.cpp
+++ b/Cbc/src/CbcModel.cpp
@@ -2372,7 +2372,7 @@ void CbcModel::branchAndBound(int doStatistics)
   if ((moreSpecialOptions2_ & (128 | 256)) != 0 && !parentModel_) {
     symmetryInfo_ = new CbcSymmetry();
     symmetryInfo_->setupSymmetry(this);
-    int numberGenerators = symmetryInfo_->statsOrbits(this, 0);
+    /*int numberGenerators =*/ symmetryInfo_->statsOrbits(this, 0);  /* FIXME can this call be removed? */
     if (!symmetryInfo_->numberUsefulOrbits() && (moreSpecialOptions2_ & (128 | 256)) != (128 | 256)) {
       delete symmetryInfo_;
       symmetryInfo_ = NULL;

--- a/Cbc/src/CbcNode.cpp
+++ b/Cbc/src/CbcNode.cpp
@@ -4111,6 +4111,7 @@ typedef struct {
    2 set if down was infeasible
    4 set if up was infeasible
  */
+static
 int solveAnalyze(void *info)
 {
   StrongBundle *bundle = reinterpret_cast< StrongBundle * >(info);

--- a/Cbc/src/CbcNode.cpp
+++ b/Cbc/src/CbcNode.cpp
@@ -4233,7 +4233,7 @@ int solveAnalyze(void *info)
         }
         choice->movement[iWay] = newObjectiveValue;
       } else {
-#ifdef COIN_HAS_CLP
+#if 0 //def COIN_HAS_CLP
         OsiClpSolverInterface *osiclp = dynamic_cast< OsiClpSolverInterface * >(solver);
         ClpSimplex *simplex = osiclp ? osiclp->getModelPtr() : NULL;
 #endif
@@ -4592,7 +4592,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
   double *currentSolution = model->currentSolution();
   double objMin = 1.0e50;
   double objMax = -1.0e50;
-  bool needResolve = false;
   int maxChoices = 1;
   int currentChoice = 0;
   int numberThreads = 0;
@@ -4763,7 +4762,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
     Now calculate the cost forcing the variable up and down.
   */
   int iDo = 0;
-  int iDone = -1;
   int numberDone = 0;
   int iThread = 0;
   int threadStatus = 0;
@@ -4805,9 +4803,7 @@ int CbcNode::analyze(CbcModel *model, double *results)
       double value = currentSolution[iColumn];
       double nearest = floor(value + 0.5);
       double lowerValue = floor(value);
-      bool satisfied = false;
       if (fabs(value - nearest) <= integerTolerance || value < saveLower[iColumn] || value > saveUpper[iColumn]) {
-        satisfied = true;
         if (nearest < saveUpper[iColumn]) {
           lowerValue = nearest;
         } else {
@@ -4965,7 +4961,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
             << CoinMessageEol;
         } else {
           // up feasible, down infeasible
-          needResolve = true;
           numberToFix++;
           saveLower[iColumn] = choice.upLowerBound;
           solver->setColLower(iColumn, choice.upLowerBound);
@@ -4978,7 +4973,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
       } else {
         if (choice.movement[0] < 1.0e100) {
           // down feasible, up infeasible
-          needResolve = true;
           numberToFix++;
           saveUpper[iColumn] = choice.downUpperBound;
           solver->setColUpper(iColumn, choice.downUpperBound);
@@ -5044,7 +5038,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
       } else {
         if (choice.movement[0] < 1.0e100) {
           // down feasible, up infeasible
-          needResolve = true;
           numberToFix++;
           saveUpper[iColumn] = lowerValue;
           solver->setColUpper(iColumn, lowerValue);
@@ -5275,7 +5268,6 @@ int CbcNode::analyze(CbcModel *model, double *results)
     double primalTolerance;
     solver->getDblParam(OsiPrimalTolerance, primalTolerance);
     iDo = 0;
-    iDone = -1;
     numberDone = 0;
     int iThread = 0;
     threadStatus = 0;

--- a/Cbc/src/CbcParam.cpp
+++ b/Cbc/src/CbcParam.cpp
@@ -34,10 +34,10 @@ CbcParam::CbcParam()
   , shortHelp_()
   , longHelp_()
   , action_(CBC_PARAM_NOTUSED_INVALID)
+  , currentKeyWord_(-1)
   , display_(false)
   , intValue_(0)
   , doubleValue_(0)
-  , currentKeyWord_(-1)
   , indexNumber_(0)
 {
 }

--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -12113,7 +12113,7 @@ static void statistics(ClpSimplex *originalModel, ClpSimplex *model)
                   }
                 } else {
                   int row2 = mapRow[iRow];
-                  assert(iRow = mapRow[row2]);
+                  assert(iRow == mapRow[row2]);
                   if (rowLower[iRow] != rowLower[row2] || rowLower[row2] != rowLower[iRow])
                     good = false;
                   CoinBigIndex offset2 = rowStart[row2] - start;

--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -5885,14 +5885,12 @@ int CbcMain1(int argc, const char *argv[],
                   // CbcObjects
                   if (preProcess && (process.numberSOS() || babModel_->numberObjects())) {
                     int numberSOS = process.numberSOS();
-                    int numberIntegers = babModel_->numberIntegers();
                     /* model may not have created objects
                                            If none then create
                                         */
                     if (!integersOK) {
                       int type = (pseudoUp) ? 1 : 0;
                       babModel_->findIntegers(true, type);
-                      numberIntegers = babModel_->numberIntegers();
                     }
                     OsiObject **oldObjects = babModel_->objects();
                     // Do sets and priorities
@@ -7478,12 +7476,6 @@ int CbcMain1(int argc, const char *argv[],
                     }
                   }
                 }
-#ifndef CBC_OTHER_SOLVER
-		{
-		  OsiClpSolverInterface *solver = dynamic_cast< OsiClpSolverInterface * >(model_.solver());
-		  ClpSimplex *simplex = solver->getModelPtr();
-		}
-#endif
                 int returnCode = CbcClpUnitTest(model_, dirMiplib, extra2, stuff,argc,argv,callBack,parameterData);
                 babModel_ = NULL;
                 return returnCode;

--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -874,6 +874,7 @@ static void signal_handler_error(int whichSignal)
   a noop when COIN_DEVELOP is not defined. To avoid compiler warnings, the
   formal parameters also need to go away.
 */
+static
 #ifdef COIN_DEVELOP
 void checkSOS(CbcModel *babModel, const OsiSolverInterface *solver)
 #else

--- a/Cbc/src/CbcSolverAnalyze.cpp
+++ b/Cbc/src/CbcSolverAnalyze.cpp
@@ -15,9 +15,8 @@
 */
 
 #include "CbcConfig.h"
+#include "CbcSolverAnalyze.hpp"
 #include "CoinPragma.hpp"
-
-#include "OsiClpSolverInterface.hpp"
 
 #include "ClpMessage.hpp"
 

--- a/Cbc/src/CbcSolverAnalyze.hpp
+++ b/Cbc/src/CbcSolverAnalyze.hpp
@@ -11,6 +11,8 @@
 #ifndef CbcSolverAnalyze_H
 #define CbcSolverAnalyze_H
 
+#include "OsiClpSolverInterface.hpp"
+
 int *analyze(OsiClpSolverInterface *solverMod, int &numberChanged,
   double &increment, bool changeInt,
   CoinMessageHandler *generalMessageHandler, bool noPrinting);

--- a/Cbc/src/CbcSolverExpandKnapsack.cpp
+++ b/Cbc/src/CbcSolverExpandKnapsack.cpp
@@ -14,11 +14,8 @@
 */
 
 #include "CbcConfig.h"
+#include "CbcSolverExpandKnapsack.hpp"
 #include "CoinPragma.hpp"
-
-#include "OsiSolverInterface.hpp"
-
-#include "CglStored.hpp"
 
 #ifndef COIN_HAS_LINK
 #define COIN_HAS_LINK

--- a/Cbc/src/CbcSolverExpandKnapsack.hpp
+++ b/Cbc/src/CbcSolverExpandKnapsack.hpp
@@ -11,6 +11,9 @@
 #ifndef CbcSolverExpandKnapsack_H
 #define CbcSolverExpandKnapsack_H
 
+#include "OsiClpSolverInterface.hpp"
+#include "CglStored.hpp"
+
 OsiSolverInterface *
 expandKnapsack(CoinModel &model, int *whichColumn, int *knapsackStart,
   int *knapsackRow, int &numberKnapsack,

--- a/Cbc/src/CbcSolverHeuristics.cpp
+++ b/Cbc/src/CbcSolverHeuristics.cpp
@@ -8,6 +8,7 @@
 */
 
 #include "CbcConfig.h"
+#include "CbcSolverHeuristics.hpp"
 #include "CoinPragma.hpp"
 
 #include "CoinTime.hpp"
@@ -15,10 +16,6 @@
 #include "OsiClpSolverInterface.hpp"
 
 #include "ClpPresolve.hpp"
-
-#include "CbcOrClpParam.hpp"
-
-#include "CbcModel.hpp"
 
 #include "CbcHeuristicLocal.hpp"
 #include "CbcHeuristicPivotAndFix.hpp"

--- a/Cbc/src/CbcSolverHeuristics.hpp
+++ b/Cbc/src/CbcSolverHeuristics.hpp
@@ -10,6 +10,9 @@
 #ifndef CbcSolverHeuristics_H
 #define CbcSolverHeuristics_H
 
+#include "CbcModel.hpp"
+#include "CbcOrClpParam.hpp"
+
 void crunchIt(ClpSimplex *model);
 
 /*

--- a/Cbc/src/CbcSymmetry.cpp
+++ b/Cbc/src/CbcSymmetry.cpp
@@ -378,7 +378,6 @@ void CbcSymmetry::setupSymmetry(CbcModel * model)
   for (iRow = 0; iRow < numberRows; iRow++) {
     for (CoinBigIndex j = rowStart[iRow];
          j < rowStart[iRow] + rowLength[iRow]; j++) {
-      int jColumn = column[j];
       double value = elementByRow[j];
       if (value != 1.0)
         num_affine++;
@@ -430,7 +429,6 @@ void CbcSymmetry::setupSymmetry(CbcModel * model)
     for (iRow = 0; iRow < numberRows; iRow++) {
       for (CoinBigIndex j = rowStart[iRow];
            j < rowStart[iRow] + rowLength[iRow]; j++) {
-        int jColumn = column[j];
         double value = elementByRow[j];
         if (value == 1.0) {
           numberElements += 2;


### PR DESCRIPTION
Fixes warnings on missing declarations, unused variables, too small buffer, signed comparison, constructor init order, assignment without affect (in assert).