### PR TITLE
Move endif in CbcSolver.hpp to the end of the file

### DIFF
--- a/src/CbcSolver.hpp
+++ b/src/CbcSolver.hpp
@@ -404,7 +404,6 @@ private:
   //@{
   //@}
 };
-#endif
 
 //###########################################################################
 // Empty callback to pass as default (why needed?)
@@ -440,3 +439,4 @@ int CbcMain1(int argc, const char *argv[],
 	     CbcModel &model,
              int callBack(CbcModel *currentSolver, int whereFrom), 
              CbcParameters &parameterData);
+#endif //CbcSolver_H


### PR DESCRIPTION
The endif was in the middle of the file, causing redefinitions when this header was included multiple times.