### PR TITLE
Update Cbc_C_Interface.cpp

### DIFF
--- a/src/Attic/Cbc_C_Interface.cpp
+++ b/src/Attic/Cbc_C_Interface.cpp
@@ -1916,6 +1916,7 @@ Cbc_solveLinearProgram(Cbc_Model *model)
 
   model->lastOptimization = ContinuousOptimization;
   solver->initialSolve();
+  fflush(stdout); fflush(stderr);
 
   if (solver->isProvenOptimal()) {
     model->obj_value = solver->getObjValue();


### PR DESCRIPTION
It happens that parts of the solution log are stuck in the buffer. This should flush the buffer before the solve function returns.