### PR TITLE
CbcSolver callback returncode not used

### DIFF
--- a/src/CbcSolver.cpp
+++ b/src/CbcSolver.cpp
@@ -3965,7 +3965,7 @@ int CbcMain1(std::deque<std::string> inputQueue, CbcModel &model,
                 si->setWarmStart(NULL);
                 int returnCode = 0;
                 if (callBack != NULL)
-                  callBack(&model_, 1);
+                  returnCode = callBack(&model_, 1);
                 if (returnCode) {
                   // exit if user wants
                   delete babModel_;


### PR DESCRIPTION
While trying to understand the CbcSolver callback return value, I believe I stumbled on a bug. The return value is not used in [line 3968 of CbcSolver.cpp](https://github.com/coin-or/Cbc/blob/master/src/CbcSolver.cpp#L3968):
```
 int returnCode = 0;
 if (callBack != NULL)
     callBack(&model_, 1);
 if (returnCode) {
```
I believe this should be `returnCode = callBack(&model_, 1);` 
Since the current code _always_ follows into the if, this change will significantly affect execution when a callback is used.
Or am I misunderstanding something?