### PR TITLE
Drop COIN_HAS_NTY from public header CbcModel.hpp

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -54,6 +54,7 @@ jobs:
           ADD_BUILD_ARGS=()
           ADD_BUILD_ARGS+=( --tests main --enable-relocatable )
           ADD_BUILD_ARGS+=( --verbosity 2 )
+          [[ ${{ matrix.os }} == ubuntu* ]] && ADD_ARGS+=( --with-nauty-incdir=/usr/include/x86_64-linux-gnu/nauty --with-nauty-lib="-L/usr/lib/ -lnauty" )
           [[ ${{ matrix.build_static }} == "true" ]] && \
           ADD_BUILD_ARGS+=( --static --with-lapack='-llapack -lblas -lgfortran -lquadmath -lm' )
           bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update \

--- a/Cbc/src/CbcModel.cpp
+++ b/Cbc/src/CbcModel.cpp
@@ -61,7 +61,9 @@ extern int gomory_try;
 #include "CbcFeasibilityBase.hpp"
 #include "CbcFathom.hpp"
 #include "CbcFullNodeInfo.hpp"
+#ifdef COIN_HAS_NTY
 #include "CbcSymmetry.hpp"
+#endif
 // include Probing
 #include "CglProbing.hpp"
 #include "CglGomory.hpp"

--- a/Cbc/src/CbcModel.cpp
+++ b/Cbc/src/CbcModel.cpp
@@ -61,9 +61,7 @@ extern int gomory_try;
 #include "CbcFeasibilityBase.hpp"
 #include "CbcFathom.hpp"
 #include "CbcFullNodeInfo.hpp"
-#ifdef COIN_HAS_NTY
 #include "CbcSymmetry.hpp"
-#endif
 // include Probing
 #include "CglProbing.hpp"
 #include "CglGomory.hpp"
@@ -5870,10 +5868,8 @@ CbcModel::CbcModel()
   , lastHeuristic_(NULL)
   , fastNodeDepth_(-1)
   , eventHandler_(NULL)
-#ifdef COIN_HAS_NTY
   , symmetryInfo_(NULL)
   , rootSymmetryInfo_(NULL)
-#endif
   , numberObjects_(0)
   , object_(NULL)
   , ownObjects_(true)
@@ -6043,10 +6039,8 @@ CbcModel::CbcModel(const OsiSolverInterface &rhs)
   , lastHeuristic_(NULL)
   , fastNodeDepth_(-1)
   , eventHandler_(NULL)
-#ifdef COIN_HAS_NTY
   , symmetryInfo_(NULL)
   , rootSymmetryInfo_(NULL)
-#endif
   , numberObjects_(0)
   , object_(NULL)
   , ownObjects_(true)

--- a/Cbc/src/CbcModel.hpp
+++ b/Cbc/src/CbcModel.hpp
@@ -2609,7 +2609,7 @@ public:
   {
     maximumNumberIterations_ = value;
   }
-#ifdef COIN_HAS_NTY
+
   /// Symmetry information
   inline CbcSymmetry *symmetryInfo() const
   {
@@ -2627,9 +2627,6 @@ public:
   {
     return rootSymmetryInfo_;
   }
-  /// get rid of all
-  void zapRootSymmetry();
-#endif
   /// Set depth for fast nodes
   inline void setFastNodeDepth(int value)
   {

--- a/Cbc/src/CbcModel.hpp
+++ b/Cbc/src/CbcModel.hpp
@@ -3115,12 +3115,10 @@ private:
 #else
   CbcEventHandler *eventHandler_;
 #endif
-#ifdef COIN_HAS_NTY
   /// Symmetry information
   CbcSymmetry *symmetryInfo_;
   /// Root symmetry information
   CbcSymmetry *rootSymmetryInfo_;
-#endif
   /// Total number of objects
   int numberObjects_;
 


### PR DESCRIPTION
COIN_HAS_NTY is only defined during compilation of Cbc but is used in public header CbcModel.hpp
Hiding attributes to 3rd party code can lead to crashes from alignment issues
We also have to unconditionnaly include CbcSymmetry.hpp in case nauty is disabled 

Fixes 1e6e3016003941406c5a63dd022c53d958111c35
Closes #591

cc @tkralphs @jjhforrest @svigerske 