### PR TITLE
Fix compiler warning and compilation with CBC_QUIET defined

### DIFF
--- a/Cbc/src/CbcNode.cpp
+++ b/Cbc/src/CbcNode.cpp
@@ -4088,7 +4088,7 @@ int CbcNode::chooseDynamicBranch(CbcModel *model, CbcNode *lastNode,
       }
     }
   } else if (model->rootSymmetryInfo() && kColumn >=0) {
-    CbcObject *obj = (dynamic_cast< CbcBranchingObject * >(branch_))->object();
+    //CbcObject *obj = (dynamic_cast< CbcBranchingObject * >(branch_))->object();
     int returnCode =
       model->rootSymmetryInfo()->changeBounds(kColumn,
 					      saveLower,saveUpper,

--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -1453,14 +1453,12 @@ int CbcMain1(int argc, const char *argv[],
       break;
     }
   }
-#if CBC_QUIET == 0
   double time0;
   double time0Elapsed = CoinGetTimeOfDay();
-#endif
   {
     double time1 = CoinCpuTime(), time2;
-#if CBC_QUIET == 0
     time0 = time1;
+#if CBC_QUIET == 0
     double time1Elapsed = time0Elapsed;
 #endif
     bool goodModel = (originalSolver->getNumCols()) ? true : false;

--- a/Cbc/src/CbcSymmetry.cpp
+++ b/Cbc/src/CbcSymmetry.cpp
@@ -573,7 +573,7 @@ CbcSymmetry::changeBounds(int iColumn, double * saveLower,
 	// OK is all same or one fixed to 0 and rest same
 	int oddOne = -1;
 	int nOdd = 0;
-	int first = i;
+	//int first = i;
 	marked[i] = 1;
 	whichMarked[nMarked++] = i;
 	int j = orbit[i];
@@ -676,7 +676,7 @@ CbcSymmetry::fixSome(int iColumn, double * columnLower,
 	// OK is all same or one fixed to 0 and rest same
 	int oddOne = -1;
 	int nOdd = 0;
-	int first = i;
+	//int first = i;
 	marked[i] = 1;
 	whichMarked[nMarked++] = i;
 	int j = orbit[i];
@@ -771,7 +771,7 @@ CbcSymmetry::changeBounds(double *saveLower,
 	  // OK is all same or one fixed to 0 and rest same
 	  int oddOne = -1;
 	  int nOdd = 0;
-	  int first = i;
+	  //int first = i;
 	  marked[i] = 1;
 	  whichMarked[nMarked++] = i;
 	  int j = orbit[i];
@@ -870,7 +870,7 @@ CbcSymmetry::changeBounds2(double *saveLower,
 	  // OK is all same or one fixed to 0 and rest same
 	  int oddOne = -1;
 	  int nOdd = 0;
-	  int first = i;
+	  //int first = i;
 	  marked[i] = 1;
 	  whichMarked[nMarked++] = i;
 	  int j = orbit[i];
@@ -949,7 +949,7 @@ CbcSymmetry::worthBranching(const double *columnLower, const double *columnUpper
   int * originalUpper = whichOrbit_ + numberColumns_;
   int * marked = originalUpper + numberColumns_;
   int * whichMarked = marked + numberColumns_;
-  int * save = whichOrbit_+4*numberColumns_;
+  //int * save = whichOrbit_+4*numberColumns_;
   memset(marked,0,numberColumns_*sizeof(int));
   for (int iPerm = 0;iPerm < numberPermutations_;iPerm++) {
     if (!permutations_[iPerm].numberPerms)
@@ -965,7 +965,7 @@ CbcSymmetry::worthBranching(const double *columnLower, const double *columnUpper
 	// OK is all same or one fixed to 0 and rest same
 	int oddOne = -1;
 	int nOdd = 0;
-	int first = i;
+	//int first = i;
 	marked[i] = 1;
 	whichMarked[nMarked++] = i;
 	int j = orbit[i];
@@ -1059,7 +1059,7 @@ CbcSymmetry::orbitalFixing2(OsiSolverInterface * solver)
 	// OK is all same or one fixed to 0 and rest same
 	int oddOne = -1;
 	int nOdd = 0;
-	int first = i;
+	//int first = i;
 	marked[i] = 1;
 	whichMarked[nMarked++] = i;
 	int j = orbit[i];
@@ -1165,7 +1165,7 @@ void CbcSymmetry::setupSymmetry(CbcModel * model)
   for (iRow = 0; iRow < numberRows; iRow++) {
     for (CoinBigIndex j = rowStart[iRow];
          j < rowStart[iRow] + rowLength[iRow]; j++) {
-      int jColumn = column[j];
+      //int jColumn = column[j];
       double value = elementByRow[j];
       if (value != 1.0)
         num_affine++;
@@ -1216,7 +1216,7 @@ void CbcSymmetry::setupSymmetry(CbcModel * model)
   for (iRow = 0; iRow < numberRows; iRow++) {
     for (CoinBigIndex j = rowStart[iRow];
 	 j < rowStart[iRow] + rowLength[iRow]; j++) {
-      int jColumn = column[j];
+      //int jColumn = column[j];
       double value = elementByRow[j];
       if (value == 1.0) {
 	numberElements += 2;
@@ -2377,7 +2377,9 @@ void CbcOrbitalBranchingObject::print()
 */
 int CbcOrbitalBranchingObject::compareOriginalObject(const CbcBranchingObject *brObj) const
 {
+#ifndef NDEBUG
   const CbcOrbitalBranchingObject *br = dynamic_cast< const CbcOrbitalBranchingObject * >(brObj);
+#endif
   assert(!br);
   abort();
   return 0;
@@ -2394,7 +2396,9 @@ int CbcOrbitalBranchingObject::compareOriginalObject(const CbcBranchingObject *b
 CbcRangeCompare
 CbcOrbitalBranchingObject::compareBranchingObject(const CbcBranchingObject *brObj, const bool replaceIfOverlap)
 {
+#ifndef NDEBUG
   const CbcOrbitalBranchingObject *br = dynamic_cast< const CbcOrbitalBranchingObject * >(brObj);
+#endif
   assert(!br);
   abort();
   return CbcRangeDisjoint;


### PR DESCRIPTION
Disable unused variables that were added with Cbc 2.10.9.

Fix that time0(Elapsed) is now also used if CBC_QUIET is defined (to nonzero).

