### PR TITLE
Add vs2022 for stable 2.10

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,6 +26,7 @@ jobs:
           { os: windows-2019, arch: i686, msystem: mingw32, debug: false, suffix: "" },
           { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
           { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: msvs, msystem: mingw64, debug: false, suffix: "" },
         ]
     steps:
       - name: Checkout source
@@ -40,11 +41,14 @@ jobs:
       - name: Set up msvc
         if: ${{ matrix.arch == 'msvc' }}
         uses: ilammy/msvc-dev-cmd@v1
+      - name: Set up for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        uses: microsoft/setup-msbuild@v1.1
       - name: Set correct host flag and install requirements
+        if: ${{ matrix.arch != 'msvc' && matrix.arch != 'msvs' }}
         run: |
           echo "host_flag=--host=${{ matrix.arch }}-w64-mingw32" | Out-File -FilePath $env:GITHUB_ENV -Encoding utf8 -Append
           C:\msys64\usr\bin\pacman -S mingw-w64-${{ matrix.arch }}-lapack mingw-w64-${{ matrix.arch }}-winpthreads-git mingw-w64-${{ matrix.arch }}-readline mingw-w64-${{ matrix.arch }}-suitesparse mingw-w64-${{ matrix.arch }}-metis --noconfirm
-        if: ${{ matrix.arch != 'msvc' }}
       - name: Set up msys with ${{ matrix.msystem }}
         uses: msys2/setup-msys2@v2
         with:
@@ -55,7 +59,42 @@ jobs:
             zip
           path-type: inherit
           msystem: ${{ matrix.msystem }}
-      - name: Build project
+      - name: Fetch project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        run: |
+          ADD_ARGS=()
+          ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
+          ./coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update "${ADD_ARGS[@]}"
+          echo "##################################################"
+          echo "### Extracting Netlib and Miplib3 if available"
+          if [ -d "./Data/Netlib/" ]; then gunzip ./Data/Netlib/*.gz; fi
+          if [ -d "./Data/Miplib3/" ]; then gunzip ./Data/Miplib3/*.gz; fi
+          echo "##################################################"       
+        shell: msys2 {0}
+      - name: Build project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          msbuild ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+      - name: Test project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
+      - name: Install project for msvs
+        if: ${{ matrix.arch == 'msvs' }}
+        shell: cmd
+        run: |
+          mkdir dist
+          copy ${{ github.event.repository.name }}\README.* dist\.
+          copy ${{ github.event.repository.name }}\AUTHORS.* dist\.
+          copy ${{ github.event.repository.name }}\LICENSE.* dist\.
+          mkdir dist\bin
+          copy ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release\*.exe dist\bin\.
+          mkdir dist\share\coin\Data
+          xcopy Data dist\share\coin\Data\. /s /e
+      - name: Build project using coinbrew
+        if: ${{ matrix.arch != 'msvs' }}
         run: |
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -80,7 +80,7 @@ jobs:
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
         run: |
-          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
+          .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}Test.cmd .\${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release .\Data\Sample .\Data\Netlib .\Data\Miplib3
       - name: Install project for msvs
         if: ${{ matrix.arch == 'msvs' }}
         shell: cmd
@@ -91,8 +91,10 @@ jobs:
           copy ${{ github.event.repository.name }}\LICENSE.* dist\.
           mkdir dist\bin
           copy ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\x64\Release\*.exe dist\bin\.
-          mkdir dist\share\coin\Data
-          xcopy Data dist\share\coin\Data\. /s /e
+          mkdir dist\share
+          if exist .\Data\Sample xcopy .\Data\Sample dist\share\coin-or-sample /i
+          if exist .\Data\Netlib xcopy .\Data\Netlib dist\share\coin-or-netlib /i
+          if exist .\Data\Miplib3 xcopy .\Data\Miplib3 dist\share\coin-or-miplib3 /i
       - name: Build project using coinbrew
         if: ${{ matrix.arch != 'msvs' }}
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,18 @@ config.log
 config.status
 libtool
 dist
+
+# Ignore VS files
+*.suo
+*.db
+*.bak
+*.user
+**/.vs/
+**/MSVisualStudio/**/Release/
+**/MSVisualStudio/**/ReleaseParallel/
+**/MSVisualStudio/**/Debug/
+
+# Ignore files created during unit tests
+**/MSVisualStudio/**/*.mps
+**/MSVisualStudio/**/*.lp
+**/MSVisualStudio/**/*.out

--- a/Cbc/MSVisualStudio/v17/Cbc.sln
+++ b/Cbc/MSVisualStudio/v17/Cbc.sln
@@ -1,0 +1,258 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.3.32804.467
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCbc", "libCbc\libCbc.vcxproj", "{0B054D74-6082-452F-9744-5FBE12C7D476}"
+	ProjectSection(ProjectDependencies) = postProject
+		{79433425-EC16-410F-9B91-8D31D2109C90} = {79433425-EC16-410F-9B91-8D31D2109C90}
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+		{BF5C7532-EE0A-479B-9993-72134087D530} = {BF5C7532-EE0A-479B-9993-72134087D530}
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB} = {1E645A44-00EF-4093-9F6A-1D082BD43BDB}
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937} = {768B67D6-E6D3-4A8F-AA61-511FDBCE7937}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCbcSolver", "libCbcSolver\libCbcSolver.vcxproj", "{5A9043A5-CB87-4E2B-807C-74830BFFAE39}"
+	ProjectSection(ProjectDependencies) = postProject
+		{79433425-EC16-410F-9B91-8D31D2109C90} = {79433425-EC16-410F-9B91-8D31D2109C90}
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+		{BF5C7532-EE0A-479B-9993-72134087D530} = {BF5C7532-EE0A-479B-9993-72134087D530}
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB} = {1E645A44-00EF-4093-9F6A-1D082BD43BDB}
+		{0B054D74-6082-452F-9744-5FBE12C7D476} = {0B054D74-6082-452F-9744-5FBE12C7D476}
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937} = {768B67D6-E6D3-4A8F-AA61-511FDBCE7937}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCoinUtils", "..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj", "{6D2EF92A-D693-47E3-A325-A686E78C5FFD}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libClp", "..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj", "{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsi", "..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj", "{BF5C7532-EE0A-479B-9993-72134087D530}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsiClp", "..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj", "{79433425-EC16-410F-9B91-8D31D2109C90}"
+	ProjectSection(ProjectDependencies) = postProject
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+		{BF5C7532-EE0A-479B-9993-72134087D530} = {BF5C7532-EE0A-479B-9993-72134087D530}
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937} = {768B67D6-E6D3-4A8F-AA61-511FDBCE7937}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libCgl", "..\..\..\..\Cgl\Cgl\MSVisualStudio\v17\libCgl\libCgl.vcxproj", "{1E645A44-00EF-4093-9F6A-1D082BD43BDB}"
+	ProjectSection(ProjectDependencies) = postProject
+		{79433425-EC16-410F-9B91-8D31D2109C90} = {79433425-EC16-410F-9B91-8D31D2109C90}
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+		{BF5C7532-EE0A-479B-9993-72134087D530} = {BF5C7532-EE0A-479B-9993-72134087D530}
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937} = {768B67D6-E6D3-4A8F-AA61-511FDBCE7937}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "cbc", "cbc\cbc.vcxproj", "{EAF01AC1-8D19-4E37-9852-736DCFF67865}"
+	ProjectSection(ProjectDependencies) = postProject
+		{79433425-EC16-410F-9B91-8D31D2109C90} = {79433425-EC16-410F-9B91-8D31D2109C90}
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD} = {6D2EF92A-D693-47E3-A325-A686E78C5FFD}
+		{BF5C7532-EE0A-479B-9993-72134087D530} = {BF5C7532-EE0A-479B-9993-72134087D530}
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB} = {1E645A44-00EF-4093-9F6A-1D082BD43BDB}
+		{0B054D74-6082-452F-9744-5FBE12C7D476} = {0B054D74-6082-452F-9744-5FBE12C7D476}
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39} = {5A9043A5-CB87-4E2B-807C-74830BFFAE39}
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937} = {768B67D6-E6D3-4A8F-AA61-511FDBCE7937}
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsiCbc", "libOsiCbc\libOsiCbc.vcxproj", "{22911998-FEDD-44AC-902F-CFEFA060C36A}"
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "libOsiCommonTest", "..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsiCommonTest\libOsiCommonTest.vcxproj", "{109D6E6F-6D91-460F-86AE-DF27400E09A9}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{FAA08B0C-E9D4-4A64-AB36-B18DB3112D87}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.gitignore = ..\..\..\.gitignore
+		..\..\..\AUTHORS = ..\..\..\AUTHORS
+		..\..\..\LICENSE = ..\..\..\LICENSE
+		..\..\..\README.md = ..\..\..\README.md
+	EndProjectSection
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "workflows", "workflows", "{02DAC099-45E6-4442-BA79-684D98557861}"
+	ProjectSection(SolutionItems) = preProject
+		..\..\..\.github\workflows\linux-ci.yml = ..\..\..\.github\workflows\linux-ci.yml
+		..\..\..\.github\workflows\release.yml = ..\..\..\.github\workflows\release.yml
+		..\..\..\.github\workflows\windows-ci.yml = ..\..\..\.github\workflows\windows-ci.yml
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "osiUnitTest", "osiUnitTest\osiUnitTest.vcxproj", "{BB058D80-D376-4F0F-87F7-E4760BC2C84D}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "test", "test", "{8611E933-9020-4D93-A72B-984AAB27425C}"
+	ProjectSection(SolutionItems) = preProject
+		CbcTest.cmd = CbcTest.cmd
+	EndProjectSection
+EndProject
+Project("{8BC9CEB8-8B4A-11D0-8D11-00A0C91BC942}") = "gamsTest", "gamsTest\gamsTest.vcxproj", "{FB60CCAF-A0F0-4557-9586-58524835E2BF}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+		ReleaseParallel|x64 = ReleaseParallel|x64
+		ReleaseParallel|x86 = ReleaseParallel|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Debug|x64.ActiveCfg = Debug|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Debug|x64.Build.0 = Debug|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Debug|x86.ActiveCfg = Debug|Win32
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Debug|x86.Build.0 = Debug|Win32
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Release|x64.ActiveCfg = Release|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Release|x64.Build.0 = Release|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Release|x86.ActiveCfg = Release|Win32
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.Release|x86.Build.0 = Release|Win32
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.ReleaseParallel|x64.ActiveCfg = ReleaseParallel|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.ReleaseParallel|x64.Build.0 = ReleaseParallel|x64
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.ReleaseParallel|x86.ActiveCfg = ReleaseParallel|Win32
+		{0B054D74-6082-452F-9744-5FBE12C7D476}.ReleaseParallel|x86.Build.0 = ReleaseParallel|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Debug|x64.ActiveCfg = Debug|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Debug|x64.Build.0 = Debug|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Debug|x86.ActiveCfg = Debug|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Debug|x86.Build.0 = Debug|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Release|x64.ActiveCfg = Release|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Release|x64.Build.0 = Release|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Release|x86.ActiveCfg = Release|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.Release|x86.Build.0 = Release|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.ReleaseParallel|x64.ActiveCfg = ReleaseParallel|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.ReleaseParallel|x64.Build.0 = ReleaseParallel|x64
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.ReleaseParallel|x86.ActiveCfg = ReleaseParallel|Win32
+		{5A9043A5-CB87-4E2B-807C-74830BFFAE39}.ReleaseParallel|x86.Build.0 = ReleaseParallel|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.ActiveCfg = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x64.Build.0 = Debug|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.ActiveCfg = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Debug|x86.Build.0 = Debug|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.ActiveCfg = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x64.Build.0 = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.ActiveCfg = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.Release|x86.Build.0 = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.ReleaseParallel|x64.Build.0 = Release|x64
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{6D2EF92A-D693-47E3-A325-A686E78C5FFD}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x64.ActiveCfg = Debug|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x64.Build.0 = Debug|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x86.ActiveCfg = Debug|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Debug|x86.Build.0 = Debug|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x64.ActiveCfg = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x64.Build.0 = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x86.ActiveCfg = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.Release|x86.Build.0 = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.ReleaseParallel|x64.Build.0 = Release|x64
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{768B67D6-E6D3-4A8F-AA61-511FDBCE7937}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x64.ActiveCfg = Debug|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x64.Build.0 = Debug|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x86.ActiveCfg = Debug|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Debug|x86.Build.0 = Debug|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x64.ActiveCfg = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x64.Build.0 = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x86.ActiveCfg = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.Release|x86.Build.0 = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.ReleaseParallel|x64.Build.0 = Release|x64
+		{BF5C7532-EE0A-479B-9993-72134087D530}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{BF5C7532-EE0A-479B-9993-72134087D530}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x64.ActiveCfg = Debug|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x64.Build.0 = Debug|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x86.ActiveCfg = Debug|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Debug|x86.Build.0 = Debug|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x64.ActiveCfg = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x64.Build.0 = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x86.ActiveCfg = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.Release|x86.Build.0 = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.ReleaseParallel|x64.Build.0 = Release|x64
+		{79433425-EC16-410F-9B91-8D31D2109C90}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{79433425-EC16-410F-9B91-8D31D2109C90}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x64.ActiveCfg = Debug|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x64.Build.0 = Debug|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x86.ActiveCfg = Debug|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Debug|x86.Build.0 = Debug|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x64.ActiveCfg = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x64.Build.0 = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x86.ActiveCfg = Release|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.Release|x86.Build.0 = Release|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.ReleaseParallel|x64.Build.0 = Release|x64
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{1E645A44-00EF-4093-9F6A-1D082BD43BDB}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Debug|x64.ActiveCfg = Debug|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Debug|x64.Build.0 = Debug|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Debug|x86.ActiveCfg = Debug|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Debug|x86.Build.0 = Debug|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Release|x64.ActiveCfg = Release|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Release|x64.Build.0 = Release|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Release|x86.ActiveCfg = Release|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.Release|x86.Build.0 = Release|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.ReleaseParallel|x64.ActiveCfg = ReleaseParallel|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.ReleaseParallel|x64.Build.0 = ReleaseParallel|x64
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.ReleaseParallel|x86.ActiveCfg = ReleaseParallel|Win32
+		{EAF01AC1-8D19-4E37-9852-736DCFF67865}.ReleaseParallel|x86.Build.0 = ReleaseParallel|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Debug|x64.ActiveCfg = Debug|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Debug|x64.Build.0 = Debug|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Debug|x86.ActiveCfg = Debug|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Debug|x86.Build.0 = Debug|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Release|x64.ActiveCfg = Release|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Release|x64.Build.0 = Release|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Release|x86.ActiveCfg = Release|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.Release|x86.Build.0 = Release|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.ReleaseParallel|x64.Build.0 = Release|x64
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{22911998-FEDD-44AC-902F-CFEFA060C36A}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Debug|x64.ActiveCfg = Debug|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Debug|x64.Build.0 = Debug|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Debug|x86.ActiveCfg = Debug|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Debug|x86.Build.0 = Debug|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x64.ActiveCfg = Release|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x64.Build.0 = Release|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x86.ActiveCfg = Release|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.Release|x86.Build.0 = Release|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.ReleaseParallel|x64.ActiveCfg = Release|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.ReleaseParallel|x64.Build.0 = Release|x64
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.ReleaseParallel|x86.ActiveCfg = Release|Win32
+		{109D6E6F-6D91-460F-86AE-DF27400E09A9}.ReleaseParallel|x86.Build.0 = Release|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Debug|x64.ActiveCfg = Debug|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Debug|x64.Build.0 = Debug|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Debug|x86.ActiveCfg = Debug|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Debug|x86.Build.0 = Debug|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Release|x64.ActiveCfg = Release|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Release|x64.Build.0 = Release|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Release|x86.ActiveCfg = Release|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.Release|x86.Build.0 = Release|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.ReleaseParallel|x64.ActiveCfg = ReleaseParallel|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.ReleaseParallel|x64.Build.0 = ReleaseParallel|x64
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.ReleaseParallel|x86.ActiveCfg = ReleaseParallel|Win32
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D}.ReleaseParallel|x86.Build.0 = ReleaseParallel|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Debug|x64.ActiveCfg = Debug|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Debug|x64.Build.0 = Debug|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Debug|x86.ActiveCfg = Debug|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Debug|x86.Build.0 = Debug|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Release|x64.ActiveCfg = Release|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Release|x64.Build.0 = Release|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Release|x86.ActiveCfg = Release|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.Release|x86.Build.0 = Release|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.ReleaseParallel|x64.ActiveCfg = ReleaseParallel|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.ReleaseParallel|x64.Build.0 = ReleaseParallel|x64
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.ReleaseParallel|x86.ActiveCfg = ReleaseParallel|Win32
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF}.ReleaseParallel|x86.Build.0 = ReleaseParallel|Win32
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{02DAC099-45E6-4442-BA79-684D98557861} = {FAA08B0C-E9D4-4A64-AB36-B18DB3112D87}
+		{BB058D80-D376-4F0F-87F7-E4760BC2C84D} = {8611E933-9020-4D93-A72B-984AAB27425C}
+		{8611E933-9020-4D93-A72B-984AAB27425C} = {FAA08B0C-E9D4-4A64-AB36-B18DB3112D87}
+		{FB60CCAF-A0F0-4557-9586-58524835E2BF} = {8611E933-9020-4D93-A72B-984AAB27425C}
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {58BF7BE6-13A3-455C-B63E-2799224131D5}
+	EndGlobalSection
+EndGlobal

--- a/Cbc/MSVisualStudio/v17/CbcTest.cmd
+++ b/Cbc/MSVisualStudio/v17/CbcTest.cmd
@@ -1,0 +1,58 @@
+@REM This file will run command line tests, comparable to test\makefile.am
+
+@echo off
+SET "BINDIR=%~1"
+SET "SAMPLEDIR=%~2"
+SET "NETLIBDIR=%~3"
+SET "MIPLIBDIR=%~4"
+
+echo INFO: Running %0 %*
+echo INFO: Using bindir '%BINDIR%', sampledir '%SAMPLEDIR%' and miplibdir '%MIPLIBDIR%'. 
+echo INFO: Netlibdir '%NETLIBDIR%' is ignored for these tests.
+
+if "%BINDIR%"=="" echo ERROR: No bindir given. && goto :usage
+if not exist "%BINDIR%" echo ERROR: Folder bindir %BINDIR% does not exist. && goto :usage
+
+if "%SAMPLEDIR%"=="" echo ERROR: No sampledir given. && goto :usage
+if not exist %SAMPLEDIR% echo ERROR: Folder sampledir %SAMPLEDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %SAMPLEDIR% cannot contain spaces. && goto :usage
+
+@REM if "%NETLIBDIR%"=="" echo ERROR: No netlibdir given. && goto :usage
+@REM if not exist %NETLIBDIR% echo ERROR: Folder netlibdir %NETLIBDIR% does not exist. && goto :usage
+@REM if not %errorlevel%==0 echo ERROR: %NETLIBDIR% cannot contain spaces. && goto :usage
+
+if "%MIPLIBDIR%"=="" echo ERROR: No miplibdir given. && goto :usage
+if not exist %MIPLIBDIR% echo ERROR: Folder miplibdir %MIPLIBDIR% does not exist. && goto :usage
+if not %errorlevel%==0 echo ERROR: %MIPLIBDIR% cannot contain spaces. && goto :usage
+
+goto :test
+
+:usage
+echo INFO: Usage %0 ^<bindir^> ^<sampledir^> ^<netlibdir^> ^<miplibdir^>
+echo INFO: where ^<bindir^> contains the executables, sampledir the sample files, netlibdir the netlib files, and miplibdir the miplib files.
+echo INFO: This script runs automated test.
+echo INFO: The sampledir, netlibdir and miplibdir must not contain spaces!
+echo INFO: Netlibdir is ignored for these tests.
+echo INFO: For example: %0 "D:\Some Directory\" ..\..\samples\ . ..\..\data-miplib
+goto :error
+
+:error
+echo ERROR: An error occurred while running the tests!
+echo INFO: Finished Tests but failed
+exit /b 1
+
+:test
+echo INFO: Starting Tests
+@echo on
+
+"%BINDIR%\gamsTest.exe"
+@if not %errorlevel%==0 goto :error
+
+"%BINDIR%\osiUnitTest.exe" -mpsDir=%SAMPLEDIR%
+@if not %errorlevel%==0 goto :error
+
+"%BINDIR%\cbc.exe" -dirMiplib %MIPLIBDIR% -unitTest
+@if not %errorlevel%==0 goto :error
+
+@echo off
+echo INFO: Finished Tests successfully (%ERRORLEVEL%)

--- a/Cbc/MSVisualStudio/v17/cbc/cbc.vcxproj
+++ b/Cbc/MSVisualStudio/v17/cbc/cbc.vcxproj
@@ -1,0 +1,252 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|Win32">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|x64">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{EAF01AC1-8D19-4E37-9852-736DCFF67865}</ProjectGuid>
+    <RootNamespace>cbc</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <LibraryPath>..\..\..\MSVisualStudio\v17\x64\Debug\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <LibraryPath>..\..\..\MSVisualStudio\v17\x64\Release\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <LibraryPath>..\..\..\..\..\pthreads-w32\pthreads.2;..\..\..\MSVisualStudio\v17\x64\Release\;$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64);$(NETFXKitsDir)Lib\um\x64</LibraryPath>
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <LibraryPath>..\..\..\MSVisualStudio\v17\Release\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <LibraryPath>..\..\..\MSVisualStudio\v17\Release\;$(VC_LibraryPath_x86);$(WindowsSDK_LibraryPath_x86);$(NETFXKitsDir)Lib\um\x86</LibraryPath>
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>NotSet</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CoinSolve.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Cgl\Cgl\MSVisualStudio\v17\libCgl\libCgl.vcxproj">
+      <Project>{1e645a44-00ef-4093-9f6a-1d082bd43bdb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbcSolver\libCbcSolver.vcxproj">
+      <Project>{5a9043a5-cb87-4e2b-807c-74830bffae39}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbc\libCbc.vcxproj">
+      <Project>{0b054d74-6082-452f-9744-5fbe12c7d476}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/MSVisualStudio/v17/gamsTest/gamsTest.vcxproj
+++ b/Cbc/MSVisualStudio/v17/gamsTest/gamsTest.vcxproj
@@ -1,0 +1,232 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|Win32">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|x64">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\gamsTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Cgl\Cgl\MSVisualStudio\v17\libCgl\libCgl.vcxproj">
+      <Project>{1e645a44-00ef-4093-9f6a-1d082bd43bdb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbcSolver\libCbcSolver.vcxproj">
+      <Project>{5a9043a5-cb87-4e2b-807c-74830bffae39}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbc\libCbc.vcxproj">
+      <Project>{0b054d74-6082-452f-9744-5fbe12c7d476}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <Keyword>Win32Proj</Keyword>
+    <ProjectGuid>{fb60ccaf-a0f0-4557-9586-58524835e2bf}</ProjectGuid>
+    <RootNamespace>gamsTest</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <LibraryPath>$(OutDir);$(VC_LibraryPath_x64);$(WindowsSDK_LibraryPath_x64)</LibraryPath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+    </Link>
+  </ItemDefinitionGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/MSVisualStudio/v17/libCbc/libCbc.vcxproj
+++ b/Cbc/MSVisualStudio/v17/libCbc/libCbc.vcxproj
@@ -1,0 +1,293 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|Win32">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|x64">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{0B054D74-6082-452F-9744-5FBE12C7D476}</ProjectGuid>
+    <RootNamespace>libCbc</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;CBC_THREAD;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;CBC_THREAD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CbcBranchAllDifferent.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchCut.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchDecision.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchDefaultDecision.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchDynamic.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchingObject.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchLotsize.cpp" />
+    <ClCompile Include="..\..\..\src\CbcBranchToFixLots.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCbcParam.cpp" />
+    <ClCompile Include="..\..\..\src\CbcClique.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCompareDefault.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCompareDepth.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCompareEstimate.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCompareObjective.cpp" />
+    <ClCompile Include="..\..\..\src\CbcConsequence.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCountRowCut.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCutGenerator.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCutModifier.cpp" />
+    <ClCompile Include="..\..\..\src\CbcCutSubsetModifier.cpp" />
+    <ClCompile Include="..\..\..\src\CbcDummyBranchingObject.cpp" />
+    <ClCompile Include="..\..\..\src\CbcEventHandler.cpp" />
+    <ClCompile Include="..\..\..\src\CbcFathom.cpp" />
+    <ClCompile Include="..\..\..\src\CbcFathomDynamicProgramming.cpp" />
+    <ClCompile Include="..\..\..\src\CbcFixVariable.cpp" />
+    <ClCompile Include="..\..\..\src\CbcFollowOn.cpp" />
+    <ClCompile Include="..\..\..\src\CbcFullNodeInfo.cpp" />
+    <ClCompile Include="..\..\..\src\CbcGeneral.cpp" />
+    <ClCompile Include="..\..\..\src\CbcGeneralDepth.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristic.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDINS.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDive.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDiveCoefficient.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDiveFractional.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDiveGuided.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDiveLineSearch.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDivePseudoCost.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDiveVectorLength.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicDW.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicFPump.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicGreedy.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicLocal.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicPivotAndFix.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicRandRound.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicRENS.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicRINS.cpp" />
+    <ClCompile Include="..\..\..\src\CbcHeuristicVND.cpp" />
+    <ClCompile Include="..\..\..\src\CbcMessage.cpp" />
+    <ClCompile Include="..\..\..\src\CbcMipStartIO.cpp" />
+    <ClCompile Include="..\..\..\src\CbcModel.cpp" />
+    <ClCompile Include="..\..\..\src\CbcNode.cpp" />
+    <ClCompile Include="..\..\..\src\CbcNodeInfo.cpp" />
+    <ClCompile Include="..\..\..\src\CbcNWay.cpp" />
+    <ClCompile Include="..\..\..\src\CbcObject.cpp" />
+    <ClCompile Include="..\..\..\src\CbcObjectUpdateData.cpp" />
+    <ClCompile Include="..\..\..\src\CbcParam.cpp" />
+    <ClCompile Include="..\..\..\src\CbcPartialNodeInfo.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSimpleInteger.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSimpleIntegerDynamicPseudoCost.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSimpleIntegerPseudoCost.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSOS.cpp" />
+    <ClCompile Include="..\..\..\src\CbcStatistics.cpp" />
+    <ClCompile Include="..\..\..\src\CbcStrategy.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSubProblem.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSymmetry.cpp" />
+    <ClCompile Include="..\..\..\src\CbcThread.cpp" />
+    <ClCompile Include="..\..\..\src\CbcTree.cpp" />
+    <ClCompile Include="..\..\..\src\CbcTreeLocal.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Cgl\Cgl\MSVisualStudio\v17\libCgl\libCgl.vcxproj">
+      <Project>{1e645a44-00ef-4093-9f6a-1d082bd43bdb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/MSVisualStudio/v17/libCbcSolver/libCbcSolver.vcxproj
+++ b/Cbc/MSVisualStudio/v17/libCbcSolver/libCbcSolver.vcxproj
@@ -1,0 +1,236 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|Win32">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|x64">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{5A9043A5-CB87-4E2B-807C-74830BFFAE39}</ProjectGuid>
+    <RootNamespace>libCbcSolver</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Label="Shared">
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Label="PropertySheets" Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <IncludePath>..\..\..\..\..\pthreads-w32\pthreads.2;$(VC_IncludePath);$(WindowsSDK_IncludePath);</IncludePath>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>Disabled</Optimization>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;CBC_THREAD;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <ClCompile>
+      <WarningLevel>Level3</WarningLevel>
+      <Optimization>MaxSpeed</Optimization>
+      <FunctionLevelLinking>true</FunctionLevelLinking>
+      <IntrinsicFunctions>true</IntrinsicFunctions>
+      <SDLCheck>true</SDLCheck>
+      <ConformanceMode>true</ConformanceMode>
+      <AdditionalIncludeDirectories>..\..\..\src\;..\..\..\..\..\Cgl\Cgl\src;..\..\..\..\..\Cgl\Cgl\src\CglClique;..\..\..\..\..\Cgl\Cgl\src\CglDuplicateRow;..\..\..\..\..\Cgl\Cgl\src\CglOddHole;..\..\..\..\..\Cgl\Cgl\src\CglFlowCover;..\..\..\..\..\Cgl\Cgl\src\CglGMI;..\..\..\..\..\Cgl\Cgl\src\CglGomory;..\..\..\..\..\Cgl\Cgl\src\CglKnapsackCover;..\..\..\..\..\Cgl\Cgl\src\CglLandP;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding;..\..\..\..\..\Cgl\Cgl\src\CglMixedIntegerRounding2;..\..\..\..\..\Cgl\Cgl\src\CglPreProcess;..\..\..\..\..\Cgl\Cgl\src\CglProbing;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit;..\..\..\..\..\Cgl\Cgl\src\CglRedSplit2;..\..\..\..\..\Cgl\Cgl\src\CglResidualCapacity;..\..\..\..\..\Cgl\Cgl\src\CglTwomir;..\..\..\..\..\Cgl\Cgl\src\CglZeroHalf;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\..\pthreads\;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>CBC_BUILD;_CRT_SECURE_NO_WARNINGS;_LIB;CBC_THREAD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <MultiProcessorCompilation>true</MultiProcessorCompilation>
+    </ClCompile>
+    <Link>
+      <SubSystem>Console</SubSystem>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <OptimizeReferences>true</OptimizeReferences>
+    </Link>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\CbcCbcParam.cpp" />
+    <ClCompile Include="..\..\..\src\CbcLinked.cpp" />
+    <ClCompile Include="..\..\..\src\CbcLinkedUtils.cpp" />
+    <ClCompile Include="..\..\..\src\CbcMipStartIO.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSolver.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSolverAnalyze.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSolverExpandKnapsack.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSolverHeuristics.cpp" />
+    <ClCompile Include="..\..\..\src\Cbc_C_Interface.cpp" />
+    <ClCompile Include="..\..\..\src\unitTestClp.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Cgl\Cgl\MSVisualStudio\v17\libCgl\libCgl.vcxproj">
+      <Project>{1e645a44-00ef-4093-9f6a-1d082bd43bdb}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbc\libCbc.vcxproj">
+      <Project>{0b054d74-6082-452f-9744-5fbe12c7d476}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/MSVisualStudio/v17/libOsiCbc/libOsiCbc.vcxproj
+++ b/Cbc/MSVisualStudio/v17/libOsiCbc/libOsiCbc.vcxproj
@@ -1,0 +1,154 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <VCProjectVersion>16.0</VCProjectVersion>
+    <ProjectGuid>{22911998-FEDD-44AC-902F-CFEFA060C36A}</ProjectGuid>
+    <RootNamespace>libOsiCbc</RootNamespace>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>StaticLibrary</ConfigurationType>
+    <UseDebugLibraries>false</UseDebugLibraries>
+    <PlatformToolset>v143</PlatformToolset>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <OutDir>$(SolutionDir)$(Configuration)\</OutDir>
+    <IntDir>$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(Platform)\$(Configuration)\</IntDir>
+  </PropertyGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_LIB;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_LIB;NDEBUG;WIN32;</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_LIB;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;..\..\..\src;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_LIB;NDEBUG;</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+      <WarningLevel>Level3</WarningLevel>
+      <DebugInformationFormat>ProgramDatabase</DebugInformationFormat>
+      <InlineFunctionExpansion>Default</InlineFunctionExpansion>
+    </ClCompile>
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\src\OsiCbc\OsiCbcSolverInterface.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ClInclude Include="..\..\..\src\OsiCbc\OsiCbcSolverInterface.hpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbc\libCbc.vcxproj">
+      <Project>{0b054d74-6082-452f-9744-5fbe12c7d476}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/MSVisualStudio/v17/osiUnitTest/osiUnitTest.vcxproj
+++ b/Cbc/MSVisualStudio/v17/osiUnitTest/osiUnitTest.vcxproj
@@ -1,0 +1,250 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <ItemGroup Label="ProjectConfigurations">
+    <ProjectConfiguration Include="Debug|Win32">
+      <Configuration>Debug</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Debug|x64">
+      <Configuration>Debug</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|Win32">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="ReleaseParallel|x64">
+      <Configuration>ReleaseParallel</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|Win32">
+      <Configuration>Release</Configuration>
+      <Platform>Win32</Platform>
+    </ProjectConfiguration>
+    <ProjectConfiguration Include="Release|x64">
+      <Configuration>Release</Configuration>
+      <Platform>x64</Platform>
+    </ProjectConfiguration>
+  </ItemGroup>
+  <PropertyGroup Label="Globals">
+    <ProjectGuid>{BB058D80-D376-4F0F-87F7-E4760BC2C84D}</ProjectGuid>
+    <RootNamespace>osiUnitTest</RootNamespace>
+    <Keyword>Win32Proj</Keyword>
+    <WindowsTargetPlatformVersion>10.0</WindowsTargetPlatformVersion>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.Default.props" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <CharacterSet>Unicode</CharacterSet>
+    <WholeProgramOptimization>true</WholeProgramOptimization>
+  </PropertyGroup>
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="Configuration">
+    <ConfigurationType>Application</ConfigurationType>
+    <PlatformToolset>v143</PlatformToolset>
+    <UseDebugLibraries>true</UseDebugLibraries>
+    <CharacterSet>Unicode</CharacterSet>
+  </PropertyGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.props" />
+  <ImportGroup Label="ExtensionSettings">
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <ImportGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" Label="PropertySheets">
+    <Import Project="$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props" Condition="exists('$(UserRootDir)\Microsoft.Cpp.$(Platform).user.props')" Label="LocalAppDataPlatform" />
+  </ImportGroup>
+  <PropertyGroup Label="UserMacros" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'" />
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" />
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|Win32'">
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;WIN32;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX86</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;_DEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <TargetMachine>MachineX64</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='ReleaseParallel|x64'">
+    <Midl>
+      <TargetEnvironment>X64</TargetEnvironment>
+    </Midl>
+    <ClCompile>
+      <AdditionalIncludeDirectories>..\..\..\src;..\..\..\src\OsiCbc;..\..\..\..\..\CoinUtils\CoinUtils\src;..\..\..\..\..\Osi\Osi\src\Osi;..\..\..\..\..\Osi\Osi\src\OsiCommonTest;..\..\..\..\..\Clp\Clp\src;..\..\..\..\..\Clp\Clp\src\OsiClp;%(AdditionalIncludeDirectories)</AdditionalIncludeDirectories>
+      <PreprocessorDefinitions>_CONSOLE;CBC_THREAD;NDEBUG;%(PreprocessorDefinitions)</PreprocessorDefinitions>
+      <PrecompiledHeader>
+      </PrecompiledHeader>
+    </ClCompile>
+    <Link>
+      <AdditionalLibraryDirectories>$(OutDir);%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <GenerateDebugInformation>true</GenerateDebugInformation>
+      <SubSystem>Console</SubSystem>
+      <OptimizeReferences>true</OptimizeReferences>
+      <EnableCOMDATFolding>true</EnableCOMDATFolding>
+      <TargetMachine>MachineX64</TargetMachine>
+      <IgnoreSpecificDefaultLibraries>
+      </IgnoreSpecificDefaultLibraries>
+      <AdditionalDependencies>pthread.lib;$(CoreLibraryDependencies);%(AdditionalDependencies)</AdditionalDependencies>
+    </Link>
+    <ProjectReference />
+  </ItemDefinitionGroup>
+  <ItemGroup>
+    <ClCompile Include="..\..\..\test\OsiCbcSolverInterfaceTest.cpp" />
+    <ClCompile Include="..\..\..\test\osiUnitTest.cpp" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libClp\libClp.vcxproj">
+      <Project>{768b67d6-e6d3-4a8f-aa61-511fdbce7937}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Clp\Clp\MSVisualStudio\v17\libOsiClp\libOsiClp.vcxproj">
+      <Project>{79433425-ec16-410f-9b91-8d31d2109c90}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\CoinUtils\CoinUtils\MSVisualStudio\v17\libCoinUtils\libCoinUtils.vcxproj">
+      <Project>{6d2ef92a-d693-47e3-a325-a686e78c5ffd}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsiCommonTest\libOsiCommonTest.vcxproj">
+      <Project>{109d6e6f-6d91-460f-86ae-df27400e09a9}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\..\..\..\..\Osi\Osi\MSVisualStudio\v17\libOsi\libOsi.vcxproj">
+      <Project>{bf5c7532-ee0a-479b-9993-72134087d530}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libCbc\libCbc.vcxproj">
+      <Project>{0b054d74-6082-452f-9744-5fbe12c7d476}</Project>
+    </ProjectReference>
+    <ProjectReference Include="..\libOsiCbc\libOsiCbc.vcxproj">
+      <Project>{22911998-fedd-44ac-902f-cfefa060c36a}</Project>
+    </ProjectReference>
+  </ItemGroup>
+  <Import Project="$(VCTargetsPath)\Microsoft.Cpp.targets" />
+  <ImportGroup Label="ExtensionTargets">
+  </ImportGroup>
+</Project>

--- a/Cbc/src/configall_system.h
+++ b/Cbc/src/configall_system.h
@@ -1,0 +1,13 @@
+/*
+ * This header file is included by the *Config.h in the individual
+ * COIN packages when the code is compiled in a setting that doesn't
+ * use the configure script (i.e., HAVE_CONFIG_H is not defined).
+ * This header file includes the system and compile dependent header
+ * file defining macros that depend on what compiler is used.
+ */
+
+#ifdef _MSC_VER
+# include "configall_system_msc.h"
+#else
+# error "Trying to use configall_system for unknown compiler."
+#endif

--- a/Cbc/src/configall_system_msc.h
+++ b/Cbc/src/configall_system_msc.h
@@ -1,0 +1,145 @@
+/* This is the header file for the Microsoft compiler, defining all
+ * system and compiler dependent configuration macros */
+
+/* Define to dummy `main' function (if any) required to link to the Fortran
+   libraries. */
+/* #undef F77_DUMMY_MAIN */
+
+#ifndef COIN_USE_F2C
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) NAME
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) NAME
+#else
+/* Define to a macro mangling the given C identifier (in lower and upper
+   case), which must not contain underscores, for linking with Fortran. */
+# define F77_FUNC(name,NAME) name ## _
+
+/* As F77_FUNC, but for C identifiers containing underscores. */
+# define F77_FUNC_(name,NAME) name ## __
+#endif
+
+/* Define if F77 and FC dummy `main' functions are identical. */
+/* #undef FC_DUMMY_MAIN_EQ_F77 */
+
+/* Define to 1 if you have the <assert.h> header file. */
+/* #undef HAVE_ASSERT_H */
+
+/* Define to 1 if you have the <cassert> header file. */
+#define HAVE_CASSERT 1
+
+/* Define to 1 if you have the <cctype> header file. */
+#define HAVE_CCTYPE 1
+
+/* Define to 1 if you have the <cfloat> header file. */
+#define HAVE_CFLOAT 1
+
+/* Define to 1 if you have the <cieeefp> header file. */
+/* #undef HAVE_CIEEEFP */
+
+/* Define to 1 if you have the <cmath> header file. */
+#define HAVE_CMATH 1
+
+/* Define to 1 if you have the <cstdarg> header file. */
+#define HAVE_CSTDARG 1
+
+/* Define to 1 if you have the <cstdio> header file. */
+#define HAVE_CSTDIO 1
+
+/* Define to 1 if you have the <cstdlib> header file. */
+#define HAVE_CSTDLIB 1
+
+/* Define to 1 if you have the <cstring> header file. */
+#define HAVE_CSTRING 1
+
+/* Define to 1 if you have the <ctime> header file. */
+#define HAVE_CTIME 1
+
+/* Define to 1 if you have the <cstddef> header file. */
+#define HAVE_CSTDDEF 1
+
+/* Define to 1 if you have the <ctype.h> header file. */
+/* #undef HAVE_CTYPE_H */
+
+/* Define to 1 if you have the <dlfcn.h> header file. */
+/* #undef HAVE_DLFCN_H */
+
+/* Define to 1 if function drand48 is available */
+/* #undef HAVE_DRAND48 */
+
+/* Define to 1 if you have the <float.h> header file. */
+/* #undef HAVE_FLOAT_H */
+
+/* Define to 1 if you have the <ieeefp.h> header file. */
+/* #undef HAVE_IEEEFP_H */
+
+/* Define to 1 if you have the <inttypes.h> header file. */
+/* #define HAVE_INTTYPES_H */
+
+/* Define to 1 if you have the <math.h> header file. */
+/* #undef HAVE_MATH_H */
+
+/* Define to 1 if you have the <memory.h> header file. */
+#define HAVE_MEMORY_H 1
+
+/* Define to 1 if function rand is available */
+#define HAVE_RAND 1
+
+/* Define to 1 if you have the <stdarg.h> header file. */
+/* #undef HAVE_STDARG_H */
+
+/* Define to 1 if you have the <stdint.h> header file. */
+/* #undef HAVE_STDINT_H */
+
+/* Define to 1 if you have the <stdio.h> header file. */
+/* #undef HAVE_STDIO_H */
+
+/* Define to 1 if you have the <stdlib.h> header file. */
+#define HAVE_STDLIB_H 1
+
+/* Define to 1 if function std::rand is available */
+#define HAVE_STD__RAND 1
+
+/* Define to 1 if you have the <strings.h> header file. */
+/* #define HAVE_STRINGS_H */
+
+/* Define to 1 if you have the <string.h> header file. */
+#define HAVE_STRING_H 1
+
+/* Define to 1 if you have the <sys/stat.h> header file. */
+#define HAVE_SYS_STAT_H 1
+
+/* Define to 1 if you have the <sys/types.h> header file. */
+#define HAVE_SYS_TYPES_H 1
+
+/* Define to 1 if you have the <time.h> header file. */
+/* #undef HAVE_TIME_H */
+
+/* Define to 1 if you have the <unistd.h> header file. */
+/* #define HAVE_UNISTD_H */
+
+/* Define to 1 if va_copy is avaliable */
+/* #undef HAVE_VA_COPY */
+
+/* Define to 1 if you have the <windows.h> header file. */
+/* #undef HAVE_WINDOWS_H */
+
+/* Define to 1 if you have the `_snprintf' function. */
+#define HAVE__SNPRINTF 1
+
+/* The size of a `double', as computed by sizeof. */
+#define SIZEOF_DOUBLE 8
+
+/* The size of a `int', as computed by sizeof. */
+#define SIZEOF_INT 4
+
+/* The size of a `int *', as computed by sizeof. */
+#define SIZEOF_INT_P 8
+
+/* The size of a `long', as computed by sizeof. */
+#define SIZEOF_LONG 4
+
+/* Define to 1 if you have the ANSI C header files. */
+#define STDC_HEADERS 1


### PR DESCRIPTION
Add VS2022 and its windows-ci to stable 2.10 and add configall_system files from master.

The Windows-ci is the same as used in [PR 214 of CoinUtils](https://github.com/coin-or/CoinUtils/pull/214).

See also similar PRs in Cgl, Clp, Osi and CoinUtils to add support for building using Visual Studio 2022 for CBC stable 2.10 and dependencies, similar to current master. 