### PR TITLE
Add option to disable dual reductions for Clp

### DIFF
--- a/src/Cbc_C_Interface.cpp
+++ b/src/Cbc_C_Interface.cpp
@@ -1763,7 +1763,7 @@ static void Cbc_addAllSOS( Cbc_Model *model, CbcModel &cbcModel );
 static void Cbc_addMS( Cbc_Model *model, CbcModel &cbcModel  );
 
 int CBC_LINKAGE
-Cbc_solveLinearProgram(Cbc_Model *model) 
+Cbc_solveLinearProgram(Cbc_Model *model, enum LPReductions red_type)
 {
   Cbc_flush( model );
   OsiClpSolverInterface *solver = model->solver_;
@@ -1909,6 +1909,16 @@ Cbc_solveLinearProgram(Cbc_Model *model)
 
   /* for integer or linear optimization starting with LP relaxation */
   ClpSolve clpOptions;
+  switch (red_type) {
+  case LPR_NoDualReds: {
+    ClpSolve options;
+    // set special option in Clp to disable dual reductions
+    clpOptions.setSpecialOption(5, 1);
+  } break;
+  case LPR_Default: {
+    break;
+  }
+  }
   char methodName[256] = "";
   switch (model->lp_method) {
     case LPM_Auto:

--- a/src/Cbc_C_Interface.cpp
+++ b/src/Cbc_C_Interface.cpp
@@ -2211,11 +2211,11 @@ static void Cbc_getMIPOptimizationResults( Cbc_Model *model, CbcModel &cbcModel 
 }
 
 int CBC_LINKAGE
-Cbc_solve(Cbc_Model *model)
+Cbc_solve(Cbc_Model *model, enum LPReductions red_type)
 {
   Cbc_cleanOptResults(model);
 
-  int res = Cbc_solveLinearProgram(model);
+  int res = Cbc_solveLinearProgram(model, red_type);
 
   if (res == 1)
     return 1;

--- a/src/Cbc_C_Interface.cpp
+++ b/src/Cbc_C_Interface.cpp
@@ -261,6 +261,7 @@ struct Cbc_Model {
   // parameters
   enum LPMethod lp_method;
   enum DualPivot dualp;
+  enum LPReductions red_type = LPR_Default;
 
   // lazy constraints
   CglStored *lazyConstrs;
@@ -1763,7 +1764,7 @@ static void Cbc_addAllSOS( Cbc_Model *model, CbcModel &cbcModel );
 static void Cbc_addMS( Cbc_Model *model, CbcModel &cbcModel  );
 
 int CBC_LINKAGE
-Cbc_solveLinearProgram(Cbc_Model *model, enum LPReductions red_type)
+Cbc_solveLinearProgram(Cbc_Model *model)
 {
   Cbc_flush( model );
   OsiClpSolverInterface *solver = model->solver_;
@@ -1909,15 +1910,9 @@ Cbc_solveLinearProgram(Cbc_Model *model, enum LPReductions red_type)
 
   /* for integer or linear optimization starting with LP relaxation */
   ClpSolve clpOptions;
-  switch (red_type) {
-  case LPR_NoDualReds: {
-    ClpSolve options;
+  if (model->red_type == LPR_NoDualReds){
     // set special option in Clp to disable dual reductions
     clpOptions.setSpecialOption(5, 1);
-  } break;
-  case LPR_Default: {
-    break;
-  }
   }
   char methodName[256] = "";
   switch (model->lp_method) {
@@ -2211,11 +2206,11 @@ static void Cbc_getMIPOptimizationResults( Cbc_Model *model, CbcModel &cbcModel 
 }
 
 int CBC_LINKAGE
-Cbc_solve(Cbc_Model *model, enum LPReductions red_type)
+Cbc_solve(Cbc_Model *model)
 {
   Cbc_cleanOptResults(model);
 
-  int res = Cbc_solveLinearProgram(model, red_type);
+  int res = Cbc_solveLinearProgram(model);
 
   if (res == 1)
     return 1;
@@ -4753,6 +4748,11 @@ Cbc_setCutoff(Cbc_Model* model, double cutoff)
 void CBC_LINKAGE
 Cbc_setLPmethod(Cbc_Model *model, enum LPMethod lpm ) {
   model->lp_method = lpm;
+}
+
+void CBC_LINKAGE
+Cbc_disableDualReds(Cbc_Model *model, enum LPReductions red) {
+  model->red_type = red;
 }
 
 

--- a/src/Cbc_C_Interface.cpp
+++ b/src/Cbc_C_Interface.cpp
@@ -4750,8 +4750,18 @@ Cbc_setLPmethod(Cbc_Model *model, enum LPMethod lpm ) {
   model->lp_method = lpm;
 }
 
+/** gets the dual reductions to be used when solving the LP
+ */
+double CBC_LINKAGE
+Cbc_getDualReductionsType(Cbc_Model *model){
+  return model->red_type;
+}
+
+/** sets the dual reductions to be used when solving the LP
+ */
+
 void CBC_LINKAGE
-Cbc_disableDualReds(Cbc_Model *model, enum LPReductions red) {
+Cbc_setDualReductionsType(Cbc_Model *model, enum LPReductions red) {
   model->red_type = red;
 }
 

--- a/src/Cbc_C_Interface.h
+++ b/src/Cbc_C_Interface.h
@@ -1087,10 +1087,16 @@ CBCLIB_EXPORT void CBC_LINKAGE
 Cbc_setLPmethod(Cbc_Model *model, enum LPMethod lpm );
 
 /**
- * sets flag to disable dual reductions when solving the LP
+ * gets type of dual reductions to use when solving the LP
+*/
+CBCLIB_EXPORT double CBC_LINKAGE
+Cbc_getDualReductionsType(Cbc_Model *model);
+
+/**
+ * sets whether not to use dual reductions when solving the LP
 */
 CBCLIB_EXPORT void CBC_LINKAGE
-Cbc_disableDualReds(Cbc_Model *model, enum LPReductions red);
+Cbc_setDualReductionsType(Cbc_Model *model, enum LPReductions red);
 
 /** Returns a pointer to the OsiClpSolverInterface object 
  * containing the problem

--- a/src/Cbc_C_Interface.h
+++ b/src/Cbc_C_Interface.h
@@ -53,6 +53,13 @@ enum LPMethod {
   LPM_BarrierNoCross = 4   /*! Barrier algorithm, not to be followed by crossover */
 };
 
+/*! Whether specific presolve reductions should be disabled
+ * */
+enum LPReductions {
+  LPR_Default = 0, /*! Solver will use default presolve transformations */
+  LPR_NoDualReds = 1 /*! Dual reduction transformation will be disabled */
+};
+
 /*! Selects the pivot selection strategy to be used
  * in the dual simplex algorithm.
  * */
@@ -1142,6 +1149,7 @@ CBCLIB_EXPORT void CBC_LINKAGE Cbc_addProgrCallback(
 /** @brief Solves the model with CBC
    *
    * @param model problem object
+   * @param red_type presolve reduction type to be used by Clp.
    * @return execution status, for MIPs: 
    *   -1 before branchAndBound 
    *   0  finished - check isProvenOptimal or isProvenInfeasible to see if solution found (or check value of best solution) 
@@ -1150,19 +1158,21 @@ CBCLIB_EXPORT void CBC_LINKAGE Cbc_addProgrCallback(
    *   5  event user programmed event occurred
    **/
 CBCLIB_EXPORT int CBC_LINKAGE
-Cbc_solve(Cbc_Model *model);
+Cbc_solve(Cbc_Model *model, enum LPReductions red_type = LPR_Default);
 
 /** @brief Solves only the linear programming relaxation
-  *
-  * @param model problem object
-  * @return execution status
-  *   0  optimal 
-  *   1  incomplete search (stopped on time, iterations)
-  *   2  infeasible
-  *   3  unbounded
-  **/
+ *
+ * @param model problem object
+ * @param reduction presolve reduction type
+ * @return execution status
+ *   0  optimal
+ *   1  incomplete search (stopped on time, iterations)
+ *   2  infeasible
+ *   3  unbounded
+ **/
 CBCLIB_EXPORT int CBC_LINKAGE
-Cbc_solveLinearProgram(Cbc_Model *model);
+Cbc_solveLinearProgram(Cbc_Model *model, enum LPReductions red_type);
+
 
 
 /** @brief This is a pre-processing that tries to 

--- a/src/Cbc_C_Interface.h
+++ b/src/Cbc_C_Interface.h
@@ -1086,6 +1086,12 @@ Cbc_setCutoff(Cbc_Model *model, double cutoff);
 CBCLIB_EXPORT void CBC_LINKAGE
 Cbc_setLPmethod(Cbc_Model *model, enum LPMethod lpm );
 
+/**
+ * sets flag to disable dual reductions when solving the LP
+*/
+CBCLIB_EXPORT void CBC_LINKAGE
+Cbc_disableDualReds(Cbc_Model *model, enum LPReductions red);
+
 /** Returns a pointer to the OsiClpSolverInterface object 
  * containing the problem
  */
@@ -1149,7 +1155,6 @@ CBCLIB_EXPORT void CBC_LINKAGE Cbc_addProgrCallback(
 /** @brief Solves the model with CBC
    *
    * @param model problem object
-   * @param red_type presolve reduction type to be used by Clp.
    * @return execution status, for MIPs: 
    *   -1 before branchAndBound 
    *   0  finished - check isProvenOptimal or isProvenInfeasible to see if solution found (or check value of best solution) 
@@ -1158,12 +1163,11 @@ CBCLIB_EXPORT void CBC_LINKAGE Cbc_addProgrCallback(
    *   5  event user programmed event occurred
    **/
 CBCLIB_EXPORT int CBC_LINKAGE
-Cbc_solve(Cbc_Model *model, enum LPReductions red_type = LPR_Default);
+Cbc_solve(Cbc_Model *model);
 
 /** @brief Solves only the linear programming relaxation
  *
  * @param model problem object
- * @param reduction presolve reduction type
  * @return execution status
  *   0  optimal
  *   1  incomplete search (stopped on time, iterations)
@@ -1171,7 +1175,7 @@ Cbc_solve(Cbc_Model *model, enum LPReductions red_type = LPR_Default);
  *   3  unbounded
  **/
 CBCLIB_EXPORT int CBC_LINKAGE
-Cbc_solveLinearProgram(Cbc_Model *model, enum LPReductions red_type);
+Cbc_solveLinearProgram(Cbc_Model *model);
 
 
 


### PR DESCRIPTION
This pull request allows users of the C interface to prevent Clp from using dual reductions during the presolving stage by specifying a reduction type when calling `Cbc_solve`. While it should be possible for users to disable presolving completely using `Cbc_setParameter`, it appears there is [an issue](https://github.com/coin-or/Cbc/issues/512) with such settings being passed to Clp from Cbc.  

Furthermore, this option is critical for users solving MIPs using lazy constraints. If one cannot disable dual reductions or disable presolving altogether then the presolving stage will delete variables such that the constraints that are inserted by the constraint handler lead to infeasibility. 

Finally, to preserve backward compatibility, the reduction type is set to a default value that does not change the Clp options by default. If the maintainers have a preferred way for ensuring that the default behavior is the same, please let me know and I can modify my PR.