### PR TITLE
Replace reinterpret_cast of NULL with static_cast

### DIFF
--- a/src/CbcModel.cpp
+++ b/src/CbcModel.cpp
@@ -6255,7 +6255,7 @@ void CbcModel::branchAndBound(int doStatistics)
     OsiClpSolverInterface *clpSolver =
         dynamic_cast<OsiClpSolverInterface *>(solver_);
     if (clpSolver)
-      clpSolver->setFakeObjective(reinterpret_cast<double *>(NULL));
+      clpSolver->setFakeObjective(static_cast<double *>(NULL));
   }
 #endif
   moreSpecialOptions_ = saveMoreSpecialOptions;


### PR DESCRIPTION
On FreeBSD and OpenBSD when using clang, `NULL` is a typedef to `nullptr`.

This same issue is described for a different instance in July of 2020 (see #319)

