### PR TITLE
Synchronize the logLevel parameter from a model.

### DIFF
--- a/src/Cbc_C_Interface.cpp
+++ b/src/Cbc_C_Interface.cpp
@@ -1103,6 +1103,9 @@ static void synchronizeParams( CbcModel *model, CbcParameters *parameters ) {
   intValue = model->getRandomSeed();
   parameters->setParamVal(CbcParam::RANDOMSEED, intValue);
 
+  intValue = model->logLevel();
+  parameters->setParamVal(CbcParam::LOGLEVEL, intValue);
+
   double doubleValue;
 
   doubleValue = model->getDblParam(CbcModel::CbcInfeasibilityWeight);


### PR DESCRIPTION
When trying to use a custom built Cbc with a recent version of python-mip, I've noticed that Cbc still prints log to stdout, despite model.verbose being set to 0. It turns out this is because this parameter was missing from the `synchronizeParams()` method. This PR fixes this. It should fix https://github.com/coin-or/python-mip/issues/359
