### PR TITLE
switch branch for ThirdParty-ASL to use newer ASL

### DIFF
--- a/.coin-or/Dependencies
+++ b/.coin-or/Dependencies
@@ -1,4 +1,4 @@
-ThirdParty/ASL    https://github.com/coin-or-tools/ThirdParty-ASL stable/2.0
+ThirdParty/ASL    https://github.com/coin-or-tools/ThirdParty-ASL stable/2.1
 ThirdParty/Glpk   https://github.com/coin-or-tools/ThirdParty-Glpk master
 ThirdParty/Mumps  https://github.com/coin-or-tools/ThirdParty-Mumps stable/3.0
 Data/Sample       https://github.com/coin-or-tools/Data-Sample master

--- a/.coin-or/config.yml
+++ b/.coin-or/config.yml
@@ -22,7 +22,7 @@ Description:
 Dependencies:
   - Description: ThirdParty wrapper for building ASL
     URL: https://github.com/coin-or-tools/ThirdParty-ASL
-    Version: stable/2.0
+    Version: stable/2.1
     Required: Optional
   - Description: ThirdParty wrapper for building Glpk
     URL: https://github.com/coin-or-tools/ThirdParty-Glpk


### PR DESCRIPTION
Updates ASL from December 2019 version to 2024-11-08.