### PR TITLE
don't solve only relaxation if there are also objects

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, ubuntu-22.04]
+        os: [ubuntu-24.04, ubuntu-22.04]
         build_static: [true, false]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-24.04, ubuntu-22.04]
+        os: [ubuntu-22.04]
         build_static: [true, false]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
         include:

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -58,7 +58,7 @@ jobs:
           ADD_ARGS=()
           ADD_ARGS+=( --skip='ThirdParty/Metis ThirdParty/Mumps ThirdParty/Blas ThirdParty/Lapack' )
           ADD_BUILD_ARGS=()
-          ADD_BUILD_ARGS+=( --build=x86_64-w64-mingw32 --tests main --enable-relocatable )
+          ADD_BUILD_ARGS+=( --build=x86_64-w64-mingw32 --tests main --enable-relocatable --disable-pkg-config)
           ADD_BUILD_ARGS+=( --verbosity 2 )
           [[ ${{ matrix.debug }} == "true" ]] && ADD_BUILD_ARGS+=( --enable-debug )
           [[ ${{ matrix.arch }} == "msvc" ]] && ADD_BUILD_ARGS+=( --enable-msvc=MD )

--- a/Cbc/src/Cbc_C_Interface.cpp
+++ b/Cbc/src/Cbc_C_Interface.cpp
@@ -845,7 +845,7 @@ Cbc_solve(Cbc_Model *model)
   Cbc_flush( model );
 
   OsiSolverInterface *solver = model->solver_;
-  if (solver->getNumIntegers() == 0 || model->relax_ == 1) {
+  if (solver->getNumIntegers() + model->model_->numberObjects() == 0 || model->relax_ == 1) {
     if (solver->basisIsAvailable()) {
       solver->resolve();
     } else {


### PR DESCRIPTION
To fix missing check for SOS from #376.

There seems to be no `CbcModel::nSos` for Cbc 2.10, but the C interface creates objects only for SOS, so the change from here should be doing the same.

I would even argue that it would be better if master also checks for any CbcObjects, and not only SOS. But when using the C interface, it probably doesn't make a difference anyway.

Many thanks to @odow for [pointing out the fix on master that needs to be ported to 2.10](https://github.com/coin-or/Cbc/issues/376#issuecomment-803666887) 4 years ago.