### PR TITLE
Update stable ci for win and linux for deprecated and new OS

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -18,9 +18,9 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04]
+        os: [ubuntu-22.04, ubuntu-24.04]
         build_static: [true, false]
-        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty2-dev]
+        download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
           - os: macos-13
             build_static: false
@@ -55,7 +55,6 @@ jobs:
           ADD_BUILD_ARGS=()
           ADD_BUILD_ARGS+=( --tests main --enable-relocatable )
           ADD_BUILD_ARGS+=( --verbosity 2 )
-          [[ ${{ matrix.os }} == ubuntu* ]] && ADD_ARGS+=( --with-nauty-incdir=/usr/include/x86_64-linux-gnu/nauty --with-nauty-lib="-L/usr/lib/ -lnauty" )
           [[ ${{ matrix.build_static }} == "true" ]] && \
           ADD_BUILD_ARGS+=( --static --with-lapack='-llapack -lblas -lgfortran -lquadmath -lm' )
           bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update \

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -55,6 +55,7 @@ jobs:
           ADD_BUILD_ARGS=()
           ADD_BUILD_ARGS+=( --tests main --enable-relocatable )
           ADD_BUILD_ARGS+=( --verbosity 2 )
+          [[ ${{ matrix.os }} == ubuntu* ]] && ADD_ARGS+=( --with-nauty-incdir=/usr/include/x86_64-linux-gnu/nauty --with-nauty-lib="-L/usr/lib/ -lnauty" )
           [[ ${{ matrix.build_static }} == "true" ]] && \
           ADD_BUILD_ARGS+=( --static --with-lapack='-llapack -lblas -lgfortran -lquadmath -lm' )
           bash coinbrew/coinbrew fetch ${{ github.event.repository.name }} --skip-update \

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -20,10 +20,10 @@ jobs:
       fail-fast: false
       matrix:
         include: [
-          { os: windows-2019, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
-          { os: windows-2019, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
-          { os: windows-2019, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
-          { os: windows-2022, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
+          { os: windows-2022, arch: x86_64, msystem: mingw64, debug: true, suffix: "-dbg" },
+          { os: windows-2025, arch: x86_64, msystem: mingw64, debug: false, suffix: "" },
+          { os: windows-2022, arch: msvc, msystem: mingw64, debug: true, suffix: "-dbg" },
+          { os: windows-2025, arch: msvc, msystem: mingw64, debug: false, suffix: "-md" },
         ]
     steps:
       - name: Checkout source

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -22,7 +22,8 @@ jobs:
         include: [
           # Only os: windows-2022 has Visual Studio 2022 (v17) installed with toolset v143, which is required.
           # configuration: "Release" or "Debug", platform: "x86" or "x64". See solution Configuration Manager.
-          { os: windows-2022, configuration: "Release", platform: "x64" },
+          { os: windows-2022, configuration: "Debug", platform: "x64" },
+          { os: windows-2025, configuration: "Release", platform: "x64" }
         ]
     steps:
       - name: Set up environment variables

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -74,7 +74,7 @@ jobs:
       - name: Build project
         shell: cmd
         run: |
-          msbuild ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=Release /p:Platform=x64 /m
+          msbuild ${{ github.event.repository.name }}\${{ github.event.repository.name }}\MSVisualStudio\v17\${{ github.event.repository.name }}.sln /p:Configuration=${{ matrix.configuration }} /p:Platform=${{ matrix.platform }} /m
       - name: Test project
         shell: cmd
         run: |


### PR DESCRIPTION
For stable branch.
See also COIN-OR-OptimizationSuite [Issue 32](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/32) and [Issue 33](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/33):

Remove Windows Server 2019 runner images for Actions are being deprecated in June 2025.
Add tests for the new Windows Server 2025 which was released Nov 2024.
Similarly, remove deprecated Ubuntu 20.04 and add new Ubuntu 24.04.
These changes are done for all ci workflows.