### PR TITLE
make it harder to trigger overflows

### DIFF
--- a/src/CbcModel.cpp
+++ b/src/CbcModel.cpp
@@ -427,7 +427,7 @@ void CbcModel::analyzeObjective()
     int numberInteger = 0;
     int numberIntegerObj = 0;
     int numberGeneralIntegerObj = 0;
-    int numberIntegerWeight = 0;
+    int64_t numberIntegerWeight = 0;
     int numberContinuousObj = 0;
     double cost = COIN_DBL_MAX;
     for (iColumn = 0; iColumn < numberColumns; iColumn++) {

--- a/src/CbcModel.cpp
+++ b/src/CbcModel.cpp
@@ -453,7 +453,7 @@ void CbcModel::analyzeObjective()
               cost = objValue;
             else if (cost != objValue)
               cost = -COIN_DBL_MAX;
-            int gap = static_cast<int>(upper[iColumn] - lower[iColumn]);
+            int64_t gap = static_cast<int64_t>(upper[iColumn] - lower[iColumn]);
             if (gap > 1) {
               numberGeneralIntegerObj++;
               numberIntegerWeight += gap;


### PR DESCRIPTION
with just int that happens fast even for 'normal problems':

src/CbcModel.cpp:459:35: runtime error: signed integer overflow: 2074221009 + 91406250 cannot be represented in type 'int'