### PR TITLE
Add outputPrecision parameter to configure precision of values.

### DIFF
--- a/src/CbcParam.hpp
+++ b/src/CbcParam.hpp
@@ -120,6 +120,7 @@ public:
       // String Parameters
       FIRSTSTRINGPARAM,
       PRINTMASK,
+      OUTPUTPRECISION,
       LASTSTRINGPARAM,
       
       // Cut Parameters

--- a/src/CbcParamUtils.hpp
+++ b/src/CbcParamUtils.hpp
@@ -30,6 +30,8 @@ int doExitParam(CoinParam &param);
 int doHelpParam(CoinParam &param);
 int doImportParam(CoinParam &param);
 int doPrintMaskParam(CoinParam &param);
+int doOutputPrecisionParam(CoinParam &param);
+
 int doNothingParam(CoinParam &param);
 int doSolutionParam(CoinParam &param);
 int doUnimplementedParam(CoinParam &param);

--- a/src/CbcParameters.cpp
+++ b/src/CbcParameters.cpp
@@ -65,6 +65,7 @@ void CbcParameters::init(int strategy){
   lastSolnOut_ = "stdout";
   printMode_ = 0;
   printMask_ = "";
+  outputPrecision_ = "%15.8g";
   noPrinting_ = false;
   printWelcome_ = true;
   useSignalHandler_ = false;
@@ -358,6 +359,7 @@ void CbcParameters::setDefaults(int strategy) {
   parameters_[CbcParam::MODELFILE]->setDefault(std::string("prob.mod"));
   parameters_[CbcParam::NEXTSOLFILE]->setDefault(std::string("next.sol"));
   parameters_[CbcParam::PRINTMASK]->setDefault("");
+  parameters_[CbcParam::OUTPUTPRECISION]->setDefault("%15.8g");
   parameters_[CbcParam::PRIORITYFILE]->setDefault(std::string("priorities.txt"));
   parameters_[CbcParam::SOLUTIONFILE]->setDefault(std::string("opt.sol"));
   parameters_[CbcParam::SOLUTIONBINARYFILE]->setDefault(std::string("solution.file"));
@@ -1130,6 +1132,13 @@ void CbcParameters::addCbcSolverStrParams() {
       "characters.  The default is '' (unset) so all variables are printed. "
       "This is only active if model has names.");
   parameters_[CbcParam::PRINTMASK]->setPushFunc(CbcParamUtils::doPrintMaskParam);
+
+  parameters_[CbcParam::OUTPUTPRECISION]->setup(
+      "output!precision", "Handle format precision with string print mask",
+      "Precision: %.nf → n digits after decimal; %.ng → n significant digits"
+      "Width: %mw → minimum field width, padded with spaces by default"
+  );
+  parameters_[CbcParam::OUTPUTPRECISION]->setPushFunc(CbcParamUtils::doOutputPrecisionParam);
 
 }
 

--- a/src/CbcParameters.hpp
+++ b/src/CbcParameters.hpp
@@ -1625,6 +1625,13 @@ public:
   /*! \brief Set print mask */
    inline void setPrintMask(std::string mask) { printMask_ = mask; }
 
+   /*! \brief Get output precision */
+   inline std::string getOutputPrecision() { return (outputPrecision_);
+  }
+
+  /*! \brief Set output precision */
+   inline void setOutputPrecision(std::string outputPrecision) { outputPrecision_ = outputPrecision; }
+
   /*! \brief Get node search strategy */
   inline CbcParameters::NodeStrategy getNodeStrategy() { return (nodeStrategy_);
   }
@@ -2068,6 +2075,8 @@ private:
       060920.
     */
   std::string printMask_;
+
+  std::string outputPrecision_;
 
   /*! \brief Disable printing altogether */
   bool noPrinting_;

--- a/src/CbcSolution.cpp
+++ b/src/CbcSolution.cpp
@@ -576,5 +576,18 @@ int CbcParamUtils::doPrintMaskParam(CoinParam &param)
   return (0);
 }
 
+int CbcParamUtils::doOutputPrecisionParam(CoinParam &param)
+{
+  CbcParam &cbcParam = dynamic_cast<CbcParam &>(param);
+  CbcParameters *parameters = cbcParam.parameters();
+  assert(parameters != 0);
+
+  std::string outputPrecision = cbcParam.strVal();
+
+  parameters->setOutputPrecision(outputPrecision);
+
+  return (0);
+}
+
 /* vi: softtabstop=2 shiftwidth=2 expandtab tabstop=2
  */

--- a/src/CbcSolver.cpp
+++ b/src/CbcSolver.cpp
@@ -181,7 +181,7 @@ void printGeneralWarning(CbcModel &model, std::string message, int type)
 #endif
 
 #ifndef CLP_OUTPUT_FORMAT
-#define CLP_OUTPUT_FORMAT % 15.8g
+char CLP_OUTPUT_FORMAT[32] = "%15.8g";
 #define CLP_INTEGER_OUTPUT_FORMAT % 15ld
 #endif
 
@@ -10292,7 +10292,16 @@ int CbcMain1(std::deque<std::string> inputQueue, CbcModel &model,
                continue;
             }
             break;
-            
+
+          case CbcParam::OUTPUTPRECISION: {
+            std::string parameter;
+            cbcParam->readValue(inputQueue, parameter, &message);
+            //printf("Handling CbcParam::OUTPUTPRECISION %s/%s\n", field.c_str(), parameter.c_str());
+            if (!parameter.empty()) {
+              std::strncpy(CLP_OUTPUT_FORMAT, parameter.c_str(), sizeof(CLP_OUTPUT_FORMAT) - 1);
+              CLP_OUTPUT_FORMAT[sizeof(CLP_OUTPUT_FORMAT) - 1] = '\0';
+            }
+            } break;
           case CbcParam::WRITEMODEL:{
             cbcParam->readValue(inputQueue, fileName, &message);
             CoinParamUtils::processFile(fileName,
@@ -11165,8 +11174,8 @@ clp watson.mps -\nscaling off\nprimalsimplex");
 
                 char printFormat[50];
                 sprintf(printFormat, " %s         %s\n",
-                        CLP_QUOTE(CLP_OUTPUT_FORMAT),
-                        CLP_QUOTE(CLP_OUTPUT_FORMAT));
+                        CLP_OUTPUT_FORMAT,
+                        CLP_OUTPUT_FORMAT);
                 char printIntFormat[50];
                 sprintf(printIntFormat, " %s         %s\n",
                         CLP_QUOTE(CLP_INTEGER_OUTPUT_FORMAT),


### PR DESCRIPTION
Add -outputPrecision parameter to cbc so that user can change precision: %.nf → n digits after decimal; %.ng → n significant digits. Default value is %15.8g.