### PR TITLE
Enable manual action runs for stable 2.10

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Linux build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Windows build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Windows MSVS build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'


### PR DESCRIPTION
Because the stable branches do not get commits often, the logs of action runs can expire. 

For CI workflows (only, not release workflow), this change adds the "workflow_dispatch" trigger to the linux-ci, windows-ci and windows-msvs-ci workflow definitions. This allows the workflow to be [manually run via the GitHub UI](https://docs.github.com/en/actions/how-tos/manage-workflow-runs/manually-run-a-workflow).