### PR TITLE
Update MSVS libCbc project for added CbcSolverStatistics.cpp

### DIFF
--- a/MSVisualStudio/v17/libCbc/libCbc.vcxproj
+++ b/MSVisualStudio/v17/libCbc/libCbc.vcxproj
@@ -267,6 +267,7 @@
     <ClCompile Include="..\..\..\src\CbcSolution.cpp" />
     <ClCompile Include="..\..\..\src\CbcSOS.cpp" />
     <ClCompile Include="..\..\..\src\CbcStatistics.cpp" />
+    <ClCompile Include="..\..\..\src\CbcSolverStatistics.cpp" />
     <ClCompile Include="..\..\..\src\CbcStrategy.cpp" />
     <ClCompile Include="..\..\..\src\CbcSubProblem.cpp" />
     <ClCompile Include="..\..\..\src\CbcSymmetry.cpp" />


### PR DESCRIPTION
To fix broken Windows MSVS ci builds due to missing CbcSolverStatistics. 