### PR TITLE
Update linux-ci to move from macos-13 to macos-15-intel

### DIFF
--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Linux build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/linux-ci.yml
+++ b/.github/workflows/linux-ci.yml
@@ -23,13 +23,13 @@ jobs:
         flags: [ADD_CXXFLAGS=-fvisibility=hidden]
         download_requirements: [sudo apt install -y -qq gfortran liblapack-dev libmetis-dev libnauty-dev]
         include:
-          - os: macos-13
+          - os: macos-15-intel
             build_static: false
-            flags: CC=clang OSX=13
+            flags: CC=clang CXX=clang++ OSX=15
             download_requirements: brew install metis bash
-          - os: macos-13
+          - os: macos-15-intel
             build_static: false
-            flags: CC=gcc-13 CXX=g++-13 OSX=13 ADD_CXXFLAGS=-Wl,-ld_classic
+            flags: CC=gcc-15 CXX=g++-15 OSX=15 ADD_CXXFLAGS=-Wl,-ld_classic
             download_requirements: brew install metis bash
           - os: macos-14
             arch: arm64

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Windows build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/.github/workflows/windows-msvs-ci.yml
+++ b/.github/workflows/windows-msvs-ci.yml
@@ -1,6 +1,7 @@
 ---
 name: Windows MSVS build and test
 on:
+  workflow_dispatch:
   push:
     branches:
       - 'master'

--- a/MSVisualStudio/v17/libCbc/libCbc.vcxproj
+++ b/MSVisualStudio/v17/libCbc/libCbc.vcxproj
@@ -250,7 +250,7 @@
     <ClCompile Include="..\..\..\src\CbcHeuristicRINS.cpp" />
     <ClCompile Include="..\..\..\src\CbcHeuristicVND.cpp" />
     <ClCompile Include="..\..\..\src\CbcMessage.cpp" />
-    <ClCompile Include="..\..\..\src\CbcMipStartIO.cpp" />
+    <ClCompile Include="..\..\..\src\CbcMipStart.cpp" />
     <ClCompile Include="..\..\..\src\CbcModel.cpp" />
     <ClCompile Include="..\..\..\src\CbcNode.cpp" />
     <ClCompile Include="..\..\..\src\CbcNodeInfo.cpp" />

--- a/MSVisualStudio/v17/libCbcSolver/libCbcSolver.vcxproj
+++ b/MSVisualStudio/v17/libCbcSolver/libCbcSolver.vcxproj
@@ -205,7 +205,7 @@
     <ClCompile Include="..\..\..\src\CbcCbcParam.cpp" />
     <ClCompile Include="..\..\..\src\CbcLinked.cpp" />
     <ClCompile Include="..\..\..\src\CbcLinkedUtils.cpp" />
-    <ClCompile Include="..\..\..\src\CbcMipStartIO.cpp" />
+    <ClCompile Include="..\..\..\src\CbcMipStart.cpp" />
     <ClCompile Include="..\..\..\src\CbcSolver.cpp" />
     <ClCompile Include="..\..\..\src\CbcSolverAnalyze.cpp" />
     <ClCompile Include="..\..\..\src\CbcSolverExpandKnapsack.cpp" />


### PR DESCRIPTION
See also COIN-OR-OptimizationSuite [Issue 35](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/35):

The macOS-13 runner image for Actions has been deprecated since 4 DEC 2025, failing runs since then.
This PR replaces the two macos-13 runners (for clang and gcc-13) in linux-ci with two macos-15-intel runners (for clang and gcc-15).

See also more information on [GitHub-hosted runners](https://docs.github.com/en/actions/reference/runners/github-hosted-runners).