### PR TITLE
fix time measurement and time limit

### DIFF
--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -4032,7 +4032,6 @@ int CbcMain1(int argc, const char *argv[],
               totalTime += time2 - time1;
 #endif
               //time1 = time2;
-              double timeLeft = babModel_->getMaximumSeconds();
               int numberOriginalColumns = babModel_->solver()->getNumCols();
               if (preProcess == 7) {
                 // use strategy instead
@@ -5073,7 +5072,6 @@ int CbcMain1(int argc, const char *argv[],
                 babModel_->setOriginalColumns(process.originalColumns(),
                   truncateColumns);
                 babModel_->initialSolve();
-                babModel_->setMaximumSeconds(timeLeft - ((useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay()) - time2));
               }
               // now tighten bounds
               if (!miplib) {

--- a/Cbc/src/CbcSolver.cpp
+++ b/Cbc/src/CbcSolver.cpp
@@ -1454,9 +1454,11 @@ int CbcMain1(int argc, const char *argv[],
   }
   double time0;
   double time0Elapsed = CoinGetTimeOfDay();
+  bool useCpuTime = !model_.useElapsedTime();
   {
-    double time1 = CoinCpuTime(), time2;
-    time0 = time1;
+    double time1, time2;
+    time1 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
+    time0 = CoinCpuTime();
 #if CBC_QUIET == 0
     double time1Elapsed = time0Elapsed;
 #endif
@@ -1962,7 +1964,7 @@ int CbcMain1(int argc, const char *argv[],
       // next command
       field = CoinReadGetCommand(argc, argv);
       // Reset time
-      time1 = CoinCpuTime();
+      time1 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #if CBC_QUIET == 0
       time1Elapsed = CoinGetTimeOfDay();
 #endif
@@ -4025,7 +4027,7 @@ int CbcMain1(int argc, const char *argv[],
               OsiSolverInterface *solver3 = model_.solver()->clone();
               babModel_->assignSolver(solver3);
 #endif
-              time2 = CoinCpuTime();
+              time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
               totalTime += time2 - time1;
 #endif
@@ -5071,7 +5073,7 @@ int CbcMain1(int argc, const char *argv[],
                 babModel_->setOriginalColumns(process.originalColumns(),
                   truncateColumns);
                 babModel_->initialSolve();
-                babModel_->setMaximumSeconds(timeLeft - (CoinCpuTime() - time2));
+                babModel_->setMaximumSeconds(timeLeft - ((useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay()) - time2));
               }
               // now tighten bounds
               if (!miplib) {
@@ -7619,7 +7621,7 @@ int CbcMain1(int argc, const char *argv[],
 #endif
               }
               // adjust time to allow for children on some systems
-              time2 = CoinCpuTime() + CoinCpuTimeJustChildren();
+              time2 = useCpuTime ? CoinCpuTime() + CoinCpuTimeJustChildren() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
               totalTime += time2 - time1;
 #endif
@@ -7774,7 +7776,6 @@ int CbcMain1(int argc, const char *argv[],
                   }
 		  // set time limit for really bad problems
 		  double timeLimit = parameters_[whichParam(CBC_PARAM_DBL_TIMELIMIT_BAB, parameters_)].doubleValue();
-		  bool useCpuTime = !model_.useElapsedTime();
 		  // But only if not stopped on time!
 		  if (!babModel_->status())
 		    setMaximumSeconds(saveSolver, timeLimit,
@@ -8381,7 +8382,7 @@ int CbcMain1(int argc, const char *argv[],
                 lengthName = 0;
                 goodModel = true;
 #endif
-                time2 = CoinCpuTime();
+                time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
                 totalTime += time2 - time1;
 #endif
@@ -8681,7 +8682,7 @@ int CbcMain1(int argc, const char *argv[],
                   }
 #endif
                 }
-                time2 = CoinCpuTime();
+                time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
                 totalTime += time2 - time1;
 #endif
@@ -9285,7 +9286,7 @@ int CbcMain1(int argc, const char *argv[],
               if (canOpen) {
                 ClpSimplex *model2 = lpSolver;
                 model2->writeBasis(fileName.c_str(), outputFormat > 1, outputFormat - 2);
-                time2 = CoinCpuTime();
+                time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
                 totalTime += time2 - time1;
 #endif
@@ -9361,7 +9362,7 @@ int CbcMain1(int argc, const char *argv[],
                 delete model2;
               if (!status) {
                 goodModel = true;
-                time2 = CoinCpuTime();
+                time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
                 totalTime += time2 - time1;
 #endif
@@ -9413,7 +9414,7 @@ int CbcMain1(int argc, const char *argv[],
               int status = lpSolver->restoreModel(fileName.c_str());
               if (!status) {
                 goodModel = true;
-                time2 = CoinCpuTime();
+                time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
                 totalTime += time2 - time1;
 #endif
@@ -10595,7 +10596,7 @@ clp watson.mps -\nscaling off\nprimalsimplex");
                 fileName = directory + field;
               }
               static_cast< ClpSimplexOther * >(lpSolver)->parametrics(fileName.c_str());
-              time2 = CoinCpuTime();
+              time2 = useCpuTime ? CoinCpuTime() : CoinGetTimeOfDay();
 #ifdef COIN_HAS_ASL
               totalTime += time2 - time1;
 #endif

--- a/Cbc/src/CbcTreeLocal.cpp
+++ b/Cbc/src/CbcTreeLocal.cpp
@@ -374,7 +374,7 @@ void CbcTreeLocal::push(CbcNode *x)
       // stop on first solution
       searchType_ = 0;
     }
-    startTime_ = static_cast< int >(CoinCpuTime());
+    startTime_ = static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime());
     saveNumberSolutions_ = model_->getSolutionCount();
   }
   nodes_.push_back(x);
@@ -407,7 +407,7 @@ bool CbcTreeLocal::empty()
   int state = 0;
   assert(searchType_ != 2);
   if (searchType_) {
-    if (CoinCpuTime() - startTime_ > timeLimit_ || model_->getNodeCount() - startNode_ >= nodeLimit_) {
+    if ((model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime()) - startTime_ > timeLimit_ || model_->getNodeCount() - startNode_ >= nodeLimit_) {
       state = 4;
     }
   } else {
@@ -441,7 +441,7 @@ bool CbcTreeLocal::empty()
     printf("local state %d after %d nodes and %d seconds, new solution %g, best solution %g, k was %g\n",
       state,
       model_->getNodeCount() - startNode_,
-      static_cast< int >(CoinCpuTime()) - startTime_,
+      static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime()) - startTime_,
       model_->getCutoff() + increment, bestCutoff_ + increment, rhs_);
   saveNumberSolutions_ = model_->getSolutionCount();
   bool finished = false;
@@ -646,7 +646,7 @@ bool CbcTreeLocal::empty()
       }
     }
     // put back node
-    startTime_ = static_cast< int >(CoinCpuTime());
+    startTime_ = static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime());
     startNode_ = model_->getNodeCount();
     if (localNode_) {
       // save copy of node
@@ -1235,7 +1235,7 @@ void CbcTreeVariable::push(CbcNode *x)
       // stop on first solution
       searchType_ = 0;
     }
-    startTime_ = static_cast< int >(CoinCpuTime());
+    startTime_ = static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime());
     saveNumberSolutions_ = model_->getSolutionCount();
   }
   nodes_.push_back(x);
@@ -1268,7 +1268,7 @@ bool CbcTreeVariable::empty()
   int state = 0;
   assert(searchType_ != 2);
   if (searchType_) {
-    if (CoinCpuTime() - startTime_ > timeLimit_ || model_->getNodeCount() - startNode_ >= nodeLimit_) {
+    if ((model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime()) - startTime_ > timeLimit_ || model_->getNodeCount() - startNode_ >= nodeLimit_) {
       state = 4;
     }
   } else {
@@ -1302,7 +1302,7 @@ bool CbcTreeVariable::empty()
     printf("local state %d after %d nodes and %d seconds, new solution %g, best solution %g, k was %g\n",
       state,
       model_->getNodeCount() - startNode_,
-      static_cast< int >(CoinCpuTime()) - startTime_,
+      static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime()) - startTime_,
       model_->getCutoff() + increment, bestCutoff_ + increment, rhs_);
   saveNumberSolutions_ = model_->getSolutionCount();
   bool finished = false;
@@ -1507,7 +1507,7 @@ bool CbcTreeVariable::empty()
       }
     }
     // put back node
-    startTime_ = static_cast< int >(CoinCpuTime());
+    startTime_ = static_cast< int >(model_->useElapsedTime() ? CoinGetTimeOfDay() : CoinCpuTime());
     startNode_ = model_->getNodeCount();
     if (localNode_) {
       // save copy of node


### PR DESCRIPTION
We were running Cbc 2.10 (via CbcMain1()) multi-threaded, and thus requested it to use wallclock (or "elapsed") time.
However, for an instance like [momentum1](https://miplib.zib.de/instance_details_momentum1.html), Cbc stopped long before the set timelimit (600s), reporting that it reached the timelimit.

The problem seemed to be the line
https://github.com/coin-or/Cbc/blob/1e06ee404caac55111ac800c5b21a2a668917478/Cbc/src/CbcSolver.cpp#L5074

1. This uses CPU seconds to compute a reduction on the timelimit, even though Cbc was instructed to use elapsed time.
2. This reduces the timelimit by the time spend in presolve. This would only make sense if also the timestamp for Cbc starts running is reset to 0, but `CbcModel::branchAndBound()` only resets `dblParam_[CbcStartSeconds]` if it hasn't been set already. However, at least for our setup, the startseconds have already been initialized in
https://github.com/coin-or/Cbc/blob/1e06ee404caac55111ac800c5b21a2a668917478/Cbc/src/CbcSolver.cpp#L2034-L2039

So with this PR,
1. time measurement is changed to elapsed time in more places in CbcSolver and CbcTreeLocal (don't know if it makes any difference for CbcTreeLocal, though), if elapsed time has been enabled.
2. Reducing the timelimit by the time spend in presolve in CbcMain1() is removed.

With these changes, Cbc now runs 53s over the timelimit, instead of stopping 130s before it (on my machine on instance momentum1).