### PR TITLE
Update windows-ci for action update for Node.js 24 to set up msvc for stable

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -38,7 +38,7 @@ jobs:
           path: coinbrew
       - name: Set up msvc
         if: ${{ matrix.arch == 'msvc' }}
-        uses: ilammy/msvc-dev-cmd@v1
+        uses: egor-tensin/vs-shell@v2
       - name: Set correct host flag and install requirements
         if: ${{ matrix.arch != 'msvc' }}
         run: |


### PR DESCRIPTION
The windows-ci.yml for masters and stables of many coin-or projects use the 
```
      - name: Set up msvc
        if: ${{ matrix.arch == 'msvc' }}
        uses: ilammy/msvc-dev-cmd@v1
```
But this action [msvc-dev-cmd](https://github.com/ilammy/msvc-dev-cmd) still uses Node.js 20. This results in Warnings in the action Runs like:
```
Node.js 20 actions are deprecated. The following actions are running on Node.js 20 
and may not work as expected: ilammy/msvc-dev-cmd@v1.
```

I propose that instead of `uses: ilammy/msvc-dev-cmd@v1` we use `uses: egor-tensin/vs-shell@v2`. This [vs-shell action](https://github.com/egor-tensin/vs-shell) is light-weight and does not use Node.js. Test runs show that such runs work and produce the same binaries. The maintainer is active, even if this action itself has not had recent releases.

See also [COIN-OR-OptimizationSuite Issue 37](https://github.com/coin-or/COIN-OR-OptimizationSuite/issues/37)