### PR TITLE
fix: use the solver's objective sense when a MIP start sets the cutoff

### DIFF
--- a/src/CbcSolver.cpp
+++ b/src/CbcSolver.cpp
@@ -9697,12 +9697,20 @@ int CbcSolver::run(std::deque< std::string > inputQueue,
               tempModel.messagesPointer());
             // set cutoff ( a trifle high)
             if (!status) {
-              double newCutoff = std::min(babModel_->getCutoff(), obj + 1.0e-4);
+              /* computeCompleteSolution returns the objective in the model's
+                 own sense, while setBestSolution and setCutoff are always
+                 minimization.  Ask the solver for the sense - CbcModel's own
+                 getObjSense() is still 1.0 here, as the model is only flipped
+                 inside branchAndBound.  Without this a maximization model got
+                 a cutoff which excludes every solution, so the mip start was
+                 returned and reported as proven optimal. */
+              double objMin = obj * babModel_->solver()->getObjSense();
+              double newCutoff = std::min(babModel_->getCutoff(), objMin + 1.0e-4);
               babModel_->setBestSolution(&x[0], static_cast< int >(x.size()),
-                obj, false);
+                objMin, false);
               babModel_->setCutoff(newCutoff);
               babModel_->setSolutionCount(1);
-              model_.setBestSolution(&x[0], static_cast< int >(x.size()), obj,
+              model_.setBestSolution(&x[0], static_cast< int >(x.size()), objMin,
                 false);
               model_.setCutoff(newCutoff);
               model_.setSolutionCount(1);
@@ -10531,8 +10539,13 @@ int CbcSolver::run(std::deque< std::string > inputQueue,
                   delete[] sosObjects;
                 }
                 /* But this is outside branchAndBound so needs to know
-                   about direction */
-                if (babModel_->getObjSense() == -1.0) {
+                   about direction.  Ask the solver - CbcModel::getObjSense()
+                   returns the (still unset) internal direction of 1.0 here,
+                   so this correction never fired and a maximization model was
+                   left with a cutoff that excludes every solution.  With
+                   preprocessing off that fathoms the root and the mip start
+                   itself is reported as proven optimal. */
+                if (babModel_->solver()->getObjSense() == -1.0) {
                   babModel_->setCutoff(-obj);
                   babModel_->setMinimizationObjValue(-obj);
                 }

--- a/src/CbcSolver.cpp
+++ b/src/CbcSolver.cpp
@@ -3757,7 +3757,13 @@ int CbcSolver::preprocess(
       if (jColumn < numberColumnsB)
         bestSolution[i] = oldBestSolution[jColumn];
     }
-    double obj = model_.getObjValue();
+    /* getObjValue returns the objective in the model's own sense, while
+       getCutoff and setCutoff are always minimization.  Mixing the two
+       gave a maximization model a negative cutoff here, which no longer
+       matches the dual objective limit already stored in the solver -
+       branchAndBound asserts on that mismatch.  Same class of bug as the
+       two mip start sites below. */
+    double obj = model_.getMinimizationObjValue();
     double newCutoff = std::min(model_.getCutoff(), obj + 1.0e-4);
     babModel_->setBestSolution(bestSolution, numberColumns, 1.0e10, false);
     babModel_->setCutoff(newCutoff);

--- a/src/CbcSolver.cpp
+++ b/src/CbcSolver.cpp
@@ -4392,6 +4392,12 @@ int CbcSolver::preprocess(
     }
   }
   babModel_->assignSolver(solver2);
+  /* assignSolver does not carry the cutoff over, so the new solver still
+     has the dual objective limit of the model preprocessing started from.
+     branchAndBound asserts that the two agree for a maximization model -
+     re-apply the cutoff we just set from the incumbent. */
+  if (model_.bestSolution())
+    babModel_->setCutoff(babModel_->getCutoff());
   babModel_->setOriginalColumns(process.originalColumns(),
     truncateColumns);
   babModel_->initialSolve();

--- a/test/CInterfaceTest.c
+++ b/test/CInterfaceTest.c
@@ -1240,6 +1240,83 @@ void testDualReductionsType( enum LPReductions red ){
     free(getname);
 }
 
+/* A MIP start must never become the answer.
+
+   The cutoff derived from a MIP start is always in minimization sense, while
+   the objective handed around at that point is in the model's own sense.
+   Mixing the two put the cutoff of a maximization model on the far side of
+   the incumbent: every improving node was fathomed at the root and Cbc
+   returned the (suboptimal) MIP start, reporting it as proven optimal.  In a
+   build with assertions enabled the resulting mismatch between the cutoff and
+   the dual objective limit trips an assertion in CbcModel::branchAndBound
+   instead.  The objective of the maximization model has to be negative for
+   the wrong cutoff to exclude anything, hence the set covering model here.
+
+   sense       -1 maximize, +1 minimize (same model, negated objective)
+   fromFile    pass the start through a *.before.mst file (used before
+               preprocessing) instead of Cbc_setMIPStart (used after it)
+   preprocess  value for the "preprocess" parameter, NULL for the default */
+void testMIPStart(double sense, char fromFile, const char *preprocess) {
+
+    /* min cost cover: 2x0 + 8x1 + 4x2 + 2x3 + 5x4 >= 10, all binary.
+       Cheapest cover is x1 = x2 = 1 at cost 5 */
+    CoinBigIndex start[] = {0, 1, 2, 3, 4, 5};
+    int rowindex[] = {0, 0, 0, 0, 0};
+    double value[] = {2, 8, 4, 2, 5};
+    double collb[] = {0, 0, 0, 0, 0};
+    double colub[] = {1, 1, 1, 1, 1};
+    double cost[] = {5, 3, 2, 7, 4};
+    double rowlb[] = {10};
+    double rowub[] = {INFINITY};
+    /* feasible but clearly suboptimal: x1 = x3 = 1, cost 10 */
+    double msValues[] = {0, 1, 0, 1, 0};
+    const char *msNames[] = {"x0", "x1", "x2", "x3", "x4"};
+    const char *fileName = "cbctest.before.mst";
+    double obj[5];
+    double expected = 5.0 * sense;
+    Cbc_Model *model = Cbc_newModel();
+    FILE *f;
+    int i;
+
+    /* maximizing the negated cost keeps the objective negative */
+    for (i = 0; i < 5; i++)
+        obj[i] = sense * cost[i];
+
+    Cbc_loadProblem(model, 5, 1, start, rowindex, value, collb, colub, obj, rowlb, rowub);
+    Cbc_setObjSense(model, sense);
+    for (i = 0; i < 5; i++) {
+        Cbc_setColName(model, i, (char *) msNames[i]);
+        Cbc_setInteger(model, i);
+    }
+
+    if (fromFile) {
+        f = fopen(fileName, "w");
+        assert(f != NULL);
+        fprintf(f, "Stopped on iterations - objective value %g\n", 10.0 * sense);
+        for (i = 0; i < 5; i++)
+            fprintf(f, "%d %s %g\n", i, msNames[i], msValues[i]);
+        fclose(f);
+        Cbc_setParameter(model, "mipstart", fileName);
+    } else {
+        Cbc_setMIPStart(model, 5, msNames, msValues);
+    }
+    if (preprocess)
+        Cbc_setParameter(model, "preprocess", preprocess);
+    Cbc_setParameter(model, "log", "0");
+
+    Cbc_solve(model);
+
+    if (fromFile)
+        remove(fileName);
+
+    assert(Cbc_isProvenOptimal(model));
+    /* the MIP start (cost 10) must have been improved on */
+    assert(fabs(Cbc_getObjValue(model) - expected) < 1e-6);
+    assert(fabs(Cbc_getBestPossibleObjValue(model) - expected) < 1e-6);
+
+    Cbc_deleteModel(model);
+}
+
 int main() {
     printf("\nStarting C Interface test.\n\n");
     char buildInfo[1024];
@@ -1273,6 +1350,13 @@ int main() {
      * lazy constraints */
     testTSPUlysses22( 1 );
     testTSPUlysses22( 0 );
+
+    printf("MIP start test\n");
+    testMIPStart(-1.0, 0, NULL);  /* maximize, start applied after preprocessing */
+    testMIPStart(-1.0, 0, "off"); /* maximize, no preprocessing */
+    testMIPStart(-1.0, 1, NULL);  /* maximize, start applied before preprocessing */
+    testMIPStart(1.0, 0, NULL);   /* same model minimized, must still work */
+    testMIPStart(1.0, 1, NULL);
 
     printf("Dual reduction type test\n");
     testDualReductionsType(LPR_Default);


### PR DESCRIPTION
A MIP start on a maximization model can make CBC return the MIP start itself and report it as proven optimal, discarding every better solution. Related to #786, which is where this was found.

### Cause

`CbcModel::getObjSense()` returns `dblParam_[CbcOptimizationDirection]`, the *internal* direction. That is 1.0 until `branchAndBound()` calls `flipModel()`, so outside `branchAndBound()` it reads 1.0 even for a maximization model. Both places in `CbcSolver::run` that install a MIP start run outside `branchAndBound()`:

* the pre-preprocessing path (`.before.` in the file name) passes `obj`, which `CbcMipStart::computeCompleteSolution` returns in the model's own sense, straight into `setBestSolution` and `setCutoff`, both of which are documented as always minimization;
* the post-preprocessing path (the default, and what PuLP's `warmStart=True` uses) already has the correction for this, guarded by `if (babModel_->getObjSense() == -1.0)` — which is never true, so it never runs.

For a maximization model the cutoff then ends up on the wrong side of the incumbent. Every node, including all improving ones, is fathomed at the root, and CBC reports the MIP start as optimal in 0 nodes. Asking the solver for the sense instead of the model fixes both sites.

### Reproduction

`stage2.mps` and the two start files from #786 (https://gist.github.com/andig/d588a5b43201334fd46824ad89dd392a). `poor.sol` is a feasible start worth `-8.61091e+07`; the true optimum is `-5.40464e+07` (maximization).

Pre-preprocessing path, current master:

```console
$ cbc stage2.mps -maximize -mips poor.before.sol -solve
file ./poor.before.sol will be used before preprocessing.
Cbc0045I MIPStart provided solution with cost -8.61091e+07
Result - Optimal solution found
Objective value:                -86109103.9307
Enumerated nodes:               0
```

Post-preprocessing path with preprocessing off, current master:

```console
$ cbc stage2.mps -maximize -mips poor.sol -preprocess off -solve
Result - Optimal solution found
Objective value:                -86109103.9307
Enumerated nodes:               0
```

Both report the start as optimal. With this patch both return `-54046441.0349`, the value the same binary proves without a MIP start.

The failure needs the maximization objective to be negative, which is when the mis-signed cutoff lands on the far side of the incumbent rather than harmlessly beyond it.

### Effect on runs that were already correct

The default path with preprocessing on was not affected by the sign error, and is unchanged here: on `stage2.mps` it still takes 5496 nodes from the optimal start and 17322 from the poor one, to the same objective. The `.before.` path, now that its cutoff is on the right side, converges in 4786 and 1798 nodes respectively.

Measured on macOS arm64, single threaded, against CoinUtils/Osi/Clp/Cgl master.
